### PR TITLE
Update rate limit to 50 requests/minute

### DIFF
--- a/tap_freshdesk/__init__.py
+++ b/tap_freshdesk/__init__.py
@@ -33,7 +33,7 @@ def get_url(endpoint, **kwargs):
     return BASE_URL.format(CONFIG['domain']) + endpoints[endpoint].format(**kwargs)
 
 
-@utils.ratelimit(100, 60)
+@utils.ratelimit(50, 60)
 def request(url, params=None):
     params = params or {}
     headers = {}


### PR DESCRIPTION
After talking with Freshdesk we would like to reduce the requests/minute to 50.