### PR TITLE
Fixes for Freshdesk API

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,14 +3,14 @@
 from setuptools import setup
 
 setup(name='tap-freshdesk',
-      version='0.6.7',
+      version='0.6.8',
       description='Singer.io tap for extracting data from the Freshdesk API',
       author='Stitch',
       url='http://singer.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_freshdesk'],
       install_requires=[
-          'singer-python>=0.2.1',
+          'singer-python==0.2.1',
           'requests==2.12.4',
       ],
       entry_points='''

--- a/tap_freshdesk/__init__.py
+++ b/tap_freshdesk/__init__.py
@@ -33,7 +33,7 @@ def get_url(endpoint, **kwargs):
     return BASE_URL.format(CONFIG['domain']) + endpoints[endpoint].format(**kwargs)
 
 
-@utils.ratelimit(1, 1)
+@utils.ratelimit(1, 2)
 def request(url, params=None):
     params = params or {}
     headers = {}
@@ -148,7 +148,8 @@ def do_sync():
     sync_time_filtered("agents")
     sync_time_filtered("roles")
     sync_time_filtered("groups")
-    sync_time_filtered("contacts")
+    # commenting out this high-volume endpoint for now
+    #sync_time_filtered("contacts")
     sync_time_filtered("companies")
 
     logger.info("Completed sync")


### PR DESCRIPTION
Fixes the following:

* Rate limiting to "once every 2 seconds"
* Stop syncing `contacts` endpoint