### PR TITLE
Added 'ticket_activities' to API calls

### DIFF
--- a/tap_freshdesk/__init__.py
+++ b/tap_freshdesk/__init__.py
@@ -56,7 +56,7 @@ def request(url, params=None, auth=None):
         retry_after = int(resp.headers['Retry-After'])
         logger.info("Rate limit reached. Sleeping for {} seconds".format(retry_after))
         time.sleep(retry_after)
-        return request(url, params)
+        return request(url, params, auth)
 
     resp.raise_for_status()
 

--- a/tap_freshdesk/schemas/ticket_activities.json
+++ b/tap_freshdesk/schemas/ticket_activities.json
@@ -1,0 +1,58 @@
+{
+    "type": "object",
+    "properties": {
+      "activity": {
+        "type": ["null", "object"],
+        "properties": {
+          "note": {
+            "type": ["null", "object"],
+            "properties": {
+              "type": {
+                "type": ["null", "integer"]
+              },
+              "id": {
+                "type": ["null", "integer"]
+              }
+            }
+          },
+          "automation": {
+            "type": ["null", "object"],
+            "properties": {
+              "type": {
+                "type": ["null", "integer"]
+              },
+              "rule": {
+                "type": ["null", "string"]
+              }
+            }
+          }
+        }
+      },
+      "performed_at": {
+        "type": [
+          "null", 
+          "string"
+        ], 
+        "format": "date-time"
+      },
+      "ticket_id": {
+        "type": [
+          "null", 
+          "integer"
+        ]
+      },
+      "performer_id": {
+        "type": [
+          "null", 
+          "integer"
+        ]
+      },
+      "performer_type": {
+        "type": [
+          "null", 
+          "string"
+        ]
+      }
+    }
+  }
+  


### PR DESCRIPTION
Changes:
 - Added new function for collecting 'ticket_activities'
 - Moved "auth" header to 'gen_request' function for further code-reuse
 - Dynamically creates schema based on 'custom_fields'

References:
 - https://support.freshdesk.com/support/solutions/articles/226460-export-ticket-activities-from-your-helpdesk