### PR TITLE
add integer as valid type to groups

### DIFF
--- a/tap_freshdesk/schemas/groups.json
+++ b/tap_freshdesk/schemas/groups.json
@@ -8,7 +8,7 @@
       }
     },
     "auto_ticket_assign": {
-      "type": ["null", "boolean"]
+      "type": ["null", "boolean", "integer"]
     },
     "business_hour_id": {
       "type": ["null", "integer"]


### PR DESCRIPTION
# Description of change
- add integer as valid type to groups
- fixes #37 
- reason: The field `auto_ticket_assign` takes on boolean AND integer values (example from the API:` "auto_ticket_assign":false` or `"auto_ticket_assign":2`), because Freshdesk uses a checkbox AND radio buttons for it, see [here](https://ibb.co/VwW7hHx).

# Manual QA steps
 - none
 
# Risks
 - should be none(?)
 
# Rollback steps
 - revert this branch
