### PR TITLE
Fix/auto ticket assign schema

### DIFF
--- a/tap_freshdesk/schemas/groups.json
+++ b/tap_freshdesk/schemas/groups.json
@@ -8,7 +8,7 @@
       }
     },
     "auto_ticket_assign": {
-      "type": ["null", "boolean"]
+      "type": ["null", "boolean", "integer"]
     },
     "business_hour_id": {
       "type": ["null", "integer"]

--- a/tap_freshdesk/schemas/groups.json
+++ b/tap_freshdesk/schemas/groups.json
@@ -8,7 +8,7 @@
       }
     },
     "auto_ticket_assign": {
-      "type": ["null", "boolean", "integer"]
+      "type": ["null", "integer", "boolean"]
     },
     "business_hour_id": {
       "type": ["null", "integer"]


### PR DESCRIPTION
# Description of change
Mimics #41 but swaps the ordering of the schema to ensure type coercion will not force `0` into `false`

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
