### PR TITLE
Sac 28832 add new metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.0
+  * Adds `parent-tap-stream-id` field to catalog [#64](https://github.com/singer-io/tap-freshdesk/pull/64)
+  * singer-python upgrade to 6.8.0
+
 ## 1.0.0
   * Complete refactoring of the tap [#60](https://github.com/singer-io/tap-freshdesk/pull/60)
   * Bump version of `requests` dependency to 2.32.3

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     classifiers=["Programming Language :: Python :: 3 :: Only"],
     py_modules=["tap_freshdesk"],
     install_requires=[
-        "requests==2.34.0",
+        "requests==2.34.2",
         "singer-python==6.8.0",
         "backoff==2.2.1"],
     entry_points="""

--- a/setup.py
+++ b/setup.py
@@ -2,15 +2,15 @@ from setuptools import setup, find_packages
 
 setup(
     name="tap-freshdesk",
-    version="1.0.0",
+    version="1.1.0",
     description="Singer.io tap for extracting data from freshdesk API",
     author="Stitch Dev",
     url="http://singer.io",
     classifiers=["Programming Language :: Python :: 3 :: Only"],
     py_modules=["tap_freshdesk"],
     install_requires=[
-        "requests==2.32.5",
-        "singer-python==6.1.0",
+        "requests==2.34.0",
+        "singer-python==6.8.0",
         "backoff==2.2.1"],
     entry_points="""
         [console_scripts]

--- a/tap_freshdesk/schema.py
+++ b/tap_freshdesk/schema.py
@@ -56,6 +56,9 @@ def get_schemas() -> Tuple[Dict, Dict]:
             replication_method=getattr(stream_obj, "replication_method"),
         )
         mdata = metadata.to_map(mdata)
+        parent_stream_id = getattr(stream_obj, "parent", None)
+        if parent_stream_id and isinstance(parent_stream_id, str):
+            mdata = metadata.write(mdata, (), "parent-tap-stream-id", parent_stream_id)
 
         automatic_keys = getattr(stream_obj, "replication_keys") or []
         for field_name in schema["properties"].keys():

--- a/tests/base.py
+++ b/tests/base.py
@@ -50,7 +50,8 @@ class FreshdeskBaseTest(BaseCase):
                 cls.REPLICATION_METHOD: cls.INCREMENTAL,
                 cls.REPLICATION_KEYS: {"updated_at"},
                 cls.EXPECTED_PAGE_SIZE: 100,
-                cls.API_LIMIT: 100
+                cls.API_LIMIT: 100,
+                cls.PARENT_TAP_STREAM_ID: "tickets"
             },
             "groups": {
                 cls.PRIMARY_KEYS: {"id"},
@@ -69,7 +70,8 @@ class FreshdeskBaseTest(BaseCase):
                 cls.REPLICATION_METHOD: cls.INCREMENTAL,
                 cls.REPLICATION_KEYS: {"updated_at"},
                 cls.EXPECTED_PAGE_SIZE: 100,
-                cls.API_LIMIT: 100
+                cls.API_LIMIT: 100,
+                cls.PARENT_TAP_STREAM_ID: "tickets"
             },
             "tickets": {
                 cls.PRIMARY_KEYS: {"id"},
@@ -83,7 +85,8 @@ class FreshdeskBaseTest(BaseCase):
                 cls.REPLICATION_METHOD: cls.INCREMENTAL,
                 cls.REPLICATION_KEYS: {"updated_at"},
                 cls.EXPECTED_PAGE_SIZE: 100,
-                cls.API_LIMIT: 100
+                cls.API_LIMIT: 100,
+                cls.PARENT_TAP_STREAM_ID: "tickets"
             },
         }
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -10,6 +10,7 @@ class FreshdeskBaseTest(BaseCase):
     """
 
     start_date = "2017-01-01T00:00:00Z"
+    PARENT_TAP_STREAM_ID = "parent-tap-stream-id"
 
     @staticmethod
     def tap_name():


### PR DESCRIPTION
# Description of change

This PR adds support for parent-child stream relationships in the Freshdesk tap by introducing a parent-tap-stream-id metadata field. This enables tracking of hierarchical relationships between streams, where child streams (conversations, time_entries, satisfaction_ratings) reference their parent stream (tickets).

[SAC-28832](https://qlik-dev.atlassian.net/browse/SAC-28832)


# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
