### PR TITLE
Added access check in discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.1.0
+  * Added per-stream access checks during discovery; streams returning 401 Unauthorized or 403 Forbidden are excluded from the catalog [#66](https://github.com/singer-io/tap-freshdesk/pull/66)
+
 ## 1.0.0
   * Complete refactoring of the tap [#60](https://github.com/singer-io/tap-freshdesk/pull/60)
   * Bump version of `requests` dependency to 2.32.3

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="tap-freshdesk",
-    version="1.0.0",
+    version="1.1.0",
     description="Singer.io tap for extracting data from freshdesk API",
     author="Stitch Dev",
     url="http://singer.io",

--- a/tap_freshdesk/__init__.py
+++ b/tap_freshdesk/__init__.py
@@ -10,10 +10,10 @@ LOGGER = singer.get_logger()
 REQUIRED_CONFIG_KEYS = ["api_key", "domain", "start_date", "user_agent"]
 
 
-def do_discover():
+def do_discover(client):
 
     LOGGER.info("Starting discover")
-    catalog = discover()
+    catalog = discover(client)
     json.dump(catalog.to_dict(), sys.stdout, indent=2)
     LOGGER.info("Finished discover")
 
@@ -28,7 +28,7 @@ def main():
 
     with Client(parsed_args.config) as client:
         if parsed_args.discover:
-            do_discover()
+            do_discover(client)
         elif parsed_args.catalog:
             sync(
                 client=client,

--- a/tap_freshdesk/discover.py
+++ b/tap_freshdesk/discover.py
@@ -69,8 +69,7 @@ def discover(client) -> Catalog:
 
     if not catalog.streams:
         raise freshdeskNoAccessibleStreamsError(
-            "No stream endpoints are accessible with the provided credentials. "
-            "Verify that the API key has the required permissions."
+            "The credentials do not have read access to any of the supported streams."
         )
 
     return catalog

--- a/tap_freshdesk/discover.py
+++ b/tap_freshdesk/discover.py
@@ -3,10 +3,37 @@ from singer import metadata
 from singer.catalog import Catalog, CatalogEntry, Schema
 from tap_freshdesk.schema import get_schemas
 from tap_freshdesk.streams import STREAMS
-from tap_freshdesk.exceptions import freshdeskUnauthorizedError, freshdeskForbiddenError
-from tap_freshdesk.utils import check_stream_access
+from tap_freshdesk.exceptions import freshdeskUnauthorizedError, freshdeskForbiddenError, freshdeskNoAccessibleStreamsError
 
 LOGGER = singer.get_logger()
+
+
+def check_stream_access(stream_name, probe_fn, auth_error_types, fallback_accessible=False):
+    """
+    Probe a stream endpoint and return True if accessible, False on auth error.
+
+    :param stream_name: Used in log messages.
+    :param probe_fn: Zero-argument callable that performs the API probe.
+    :param auth_error_types: Exception type(s) indicating 401/403 — returns False.
+    :param fallback_accessible: If True, non-auth errors (e.g. 400 from minimal
+                                probe params) are treated as auth-OK and return True.
+                                If False (default), they are re-raised.
+    """
+    try:
+        probe_fn()
+        LOGGER.info("Stream '%s' is accessible.", stream_name)
+        return True
+    except auth_error_types:
+        LOGGER.warning(
+            "Stream '%s' is not accessible with the provided credentials.",
+            stream_name,
+        )
+        return False
+    except Exception:  # pylint: disable=broad-except
+        if fallback_accessible:
+            LOGGER.info("Stream '%s' endpoint reachable (auth OK).", stream_name)
+            return True
+        raise
 
 
 def _check_stream_access(client, stream_name, stream_class) -> bool:
@@ -42,6 +69,10 @@ def discover(client) -> Catalog:
 
     for stream_name, schema_dict in schemas.items():
         if not _check_stream_access(client, stream_name, STREAMS[stream_name]):
+            LOGGER.warning(
+                "Stream '%s' will be excluded from the catalog due to insufficient permissions.",
+                stream_name,
+            )
             continue
 
         try:
@@ -63,6 +94,12 @@ def discover(client) -> Catalog:
                 schema=schema,
                 metadata=mdata,
             )
+        )
+
+    if not catalog.streams:
+        raise freshdeskNoAccessibleStreamsError(
+            "No stream endpoints are accessible with the provided credentials. "
+            "Verify that the API key has the required permissions."
         )
 
     return catalog

--- a/tap_freshdesk/discover.py
+++ b/tap_freshdesk/discover.py
@@ -8,55 +8,26 @@ from tap_freshdesk.exceptions import freshdeskUnauthorizedError, freshdeskForbid
 LOGGER = singer.get_logger()
 
 
-def check_stream_access(stream_name, probe_fn, auth_error_types, fallback_accessible=False):
+def check_stream_access(client, stream_class) -> bool:
     """
-    Probe a stream endpoint and return True if accessible, False on auth error.
-
-    :param stream_name: Used in log messages.
-    :param probe_fn: Zero-argument callable that performs the API probe.
-    :param auth_error_types: Exception type(s) indicating 401/403 — returns False.
-    :param fallback_accessible: If True, non-auth errors (e.g. 400 from minimal
-                                probe params) are treated as auth-OK and return True.
-                                If False (default), they are re-raised.
-    """
-    try:
-        probe_fn()
-        LOGGER.info("Stream '%s' is accessible.", stream_name)
-        return True
-    except auth_error_types:
-        LOGGER.warning(
-            "Stream '%s' is not accessible with the provided credentials.",
-            stream_name,
-        )
-        return False
-    except Exception:  # pylint: disable=broad-except
-        if fallback_accessible:
-            LOGGER.info("Stream '%s' endpoint reachable (auth OK).", stream_name)
-            return True
-        raise
-
-
-def _check_stream_access(client, stream_name, stream_class) -> bool:
-    """
-    Probes a stream endpoint with page_size=1 to verify the credentials have
-    access. Child streams whose path contains '{}' (they require a parent ID)
-    are skipped and assumed accessible.
-    Returns True if accessible, False on 401/403.
+    Probes a stream endpoint with page_size=1 to verify the credentials have access.
+    Child streams whose path contains '{}' require a parent ID and cannot be probed,
+    so they are assumed accessible.
+    Returns True if accessible, False on 401/403. Any other exception is re-raised.
     """
     if '{}' in stream_class.path:
-        # Child streams cannot be probed without a parent ID — skip and include.
         return True
 
     endpoint = f"{client.base_url}/{stream_class.path}"
-    return check_stream_access(
-        stream_name,
-        probe_fn=lambda: client.get(
+    try:
+        client.get(
             endpoint=endpoint,
             params={"per_page": 1, "page": 1},
             headers={"Accept": "application/json"},
-        ),
-        auth_error_types=(freshdeskUnauthorizedError, freshdeskForbiddenError),
-    )
+        )
+        return True
+    except (freshdeskUnauthorizedError, freshdeskForbiddenError):
+        return False
 
 
 def discover(client) -> Catalog:
@@ -68,7 +39,7 @@ def discover(client) -> Catalog:
     catalog = Catalog([])
 
     for stream_name, schema_dict in schemas.items():
-        if not _check_stream_access(client, stream_name, STREAMS[stream_name]):
+        if not check_stream_access(client, STREAMS[stream_name]):
             LOGGER.warning(
                 "Stream '%s' will be excluded from the catalog due to insufficient permissions.",
                 stream_name,

--- a/tap_freshdesk/discover.py
+++ b/tap_freshdesk/discover.py
@@ -2,16 +2,48 @@ import singer
 from singer import metadata
 from singer.catalog import Catalog, CatalogEntry, Schema
 from tap_freshdesk.schema import get_schemas
+from tap_freshdesk.streams import STREAMS
+from tap_freshdesk.exceptions import freshdeskUnauthorizedError, freshdeskForbiddenError
+from tap_freshdesk.utils import check_stream_access
 
 LOGGER = singer.get_logger()
 
 
-def discover() -> Catalog:
-    """Run the discovery mode, prepare the catalog file and return the catalog."""
+def _check_stream_access(client, stream_name, stream_class) -> bool:
+    """
+    Probes a stream endpoint with page_size=1 to verify the credentials have
+    access. Child streams whose path contains '{}' (they require a parent ID)
+    are skipped and assumed accessible.
+    Returns True if accessible, False on 401/403.
+    """
+    if '{}' in stream_class.path:
+        # Child streams cannot be probed without a parent ID — skip and include.
+        return True
+
+    endpoint = f"{client.base_url}/{stream_class.path}"
+    return check_stream_access(
+        stream_name,
+        probe_fn=lambda: client.get(
+            endpoint=endpoint,
+            params={"per_page": 1, "page": 1},
+            headers={"Accept": "application/json"},
+        ),
+        auth_error_types=(freshdeskUnauthorizedError, freshdeskForbiddenError),
+    )
+
+
+def discover(client) -> Catalog:
+    """Run the discovery mode, prepare the catalog file and return the catalog.
+    Probes each top-level stream endpoint to verify access; streams that return
+    401/403 are excluded from the catalog.
+    """
     schemas, field_metadata = get_schemas()
     catalog = Catalog([])
 
     for stream_name, schema_dict in schemas.items():
+        if not _check_stream_access(client, stream_name, STREAMS[stream_name]):
+            continue
+
         try:
             schema = Schema.from_dict(schema_dict)
             mdata = field_metadata[stream_name]

--- a/tap_freshdesk/exceptions.py
+++ b/tap_freshdesk/exceptions.py
@@ -7,6 +7,12 @@ class freshdeskError(Exception):
         self.response = response
 
 
+class freshdeskNoAccessibleStreamsError(freshdeskError):
+    """Raised during discovery when no stream endpoints are accessible with the provided credentials."""
+
+    pass
+
+
 class freshdeskBackoffError(freshdeskError):
     """Class representing backoff error handling."""
 

--- a/tap_freshdesk/utils.py
+++ b/tap_freshdesk/utils.py
@@ -15,26 +15,14 @@ LOGGER = singer.get_logger()
 
 def check_stream_access(stream_name, probe_fn, auth_error_types, fallback_accessible=False):
     """
-    Standard Singer tap stream access checker.
+    Probe a stream endpoint and return True if accessible, False on auth error.
 
-    Calls ``probe_fn()`` (a zero-argument callable that performs a lightweight
-    API request) to verify whether the configured credentials can reach the
-    stream's endpoint. Streams that raise an auth error are excluded from the
-    catalog by returning False.
-
-    :param stream_name: Stream name used in log messages.
-    :param probe_fn: Zero-argument callable that performs the API probe request.
-    :param auth_error_types: Exception type or tuple of exception types that
-                             indicate an authentication / authorization failure
-                             (e.g. 401 / 403). These cause the function to
-                             return False and log a warning.
-    :param fallback_accessible: When True, any exception *other* than
-                                ``auth_error_types`` is treated as "endpoint
-                                reachable, auth OK" (e.g. a 400 caused by
-                                intentionally minimal probe params) and the
-                                function returns True. When False (default)
-                                unexpected exceptions are re-raised.
-    :return: True if the stream is accessible, False if an auth error is raised.
+    :param stream_name: Used in log messages.
+    :param probe_fn: Zero-argument callable that performs the API probe.
+    :param auth_error_types: Exception type(s) indicating 401/403 — returns False.
+    :param fallback_accessible: If True, non-auth errors (e.g. 400 from minimal
+                                probe params) are treated as auth-OK and return True.
+                                If False (default), they are re-raised.
     """
     try:
         probe_fn()

--- a/tap_freshdesk/utils.py
+++ b/tap_freshdesk/utils.py
@@ -13,35 +13,6 @@ DATETIME_FMT = "%Y-%m-%dT%H:%M:%SZ"
 LOGGER = singer.get_logger()
 
 
-def check_stream_access(stream_name, probe_fn, auth_error_types, fallback_accessible=False):
-    """
-    Probe a stream endpoint and return True if accessible, False on auth error.
-
-    :param stream_name: Used in log messages.
-    :param probe_fn: Zero-argument callable that performs the API probe.
-    :param auth_error_types: Exception type(s) indicating 401/403 — returns False.
-    :param fallback_accessible: If True, non-auth errors (e.g. 400 from minimal
-                                probe params) are treated as auth-OK and return True.
-                                If False (default), they are re-raised.
-    """
-    try:
-        probe_fn()
-        LOGGER.info("Stream '%s' is accessible.", stream_name)
-        return True
-    except auth_error_types:
-        LOGGER.warning(
-            "Stream '%s' is not accessible with the provided credentials. "
-            "It will be excluded from the catalog.",
-            stream_name,
-        )
-        return False
-    except Exception:
-        if fallback_accessible:
-            LOGGER.info("Stream '%s' endpoint reachable (auth OK).", stream_name)
-            return True
-        raise
-
-
 def strptime(dt):
     return datetime.datetime.strptime(dt, DATETIME_FMT)
 

--- a/tap_freshdesk/utils.py
+++ b/tap_freshdesk/utils.py
@@ -6,7 +6,52 @@ import json
 import os
 import time
 
+import singer
+
 DATETIME_FMT = "%Y-%m-%dT%H:%M:%SZ"
+
+LOGGER = singer.get_logger()
+
+
+def check_stream_access(stream_name, probe_fn, auth_error_types, fallback_accessible=False):
+    """
+    Standard Singer tap stream access checker.
+
+    Calls ``probe_fn()`` (a zero-argument callable that performs a lightweight
+    API request) to verify whether the configured credentials can reach the
+    stream's endpoint. Streams that raise an auth error are excluded from the
+    catalog by returning False.
+
+    :param stream_name: Stream name used in log messages.
+    :param probe_fn: Zero-argument callable that performs the API probe request.
+    :param auth_error_types: Exception type or tuple of exception types that
+                             indicate an authentication / authorization failure
+                             (e.g. 401 / 403). These cause the function to
+                             return False and log a warning.
+    :param fallback_accessible: When True, any exception *other* than
+                                ``auth_error_types`` is treated as "endpoint
+                                reachable, auth OK" (e.g. a 400 caused by
+                                intentionally minimal probe params) and the
+                                function returns True. When False (default)
+                                unexpected exceptions are re-raised.
+    :return: True if the stream is accessible, False if an auth error is raised.
+    """
+    try:
+        probe_fn()
+        LOGGER.info("Stream '%s' is accessible.", stream_name)
+        return True
+    except auth_error_types:
+        LOGGER.warning(
+            "Stream '%s' is not accessible with the provided credentials. "
+            "It will be excluded from the catalog.",
+            stream_name,
+        )
+        return False
+    except Exception:  # pylint: disable=broad-except
+        if fallback_accessible:
+            LOGGER.info("Stream '%s' endpoint reachable (auth OK).", stream_name)
+            return True
+        raise
 
 
 def strptime(dt):

--- a/tap_freshdesk/utils.py
+++ b/tap_freshdesk/utils.py
@@ -47,7 +47,7 @@ def check_stream_access(stream_name, probe_fn, auth_error_types, fallback_access
             stream_name,
         )
         return False
-    except Exception:  # pylint: disable=broad-except
+    except Exception:
         if fallback_accessible:
             LOGGER.info("Stream '%s' endpoint reachable (auth OK).", stream_name)
             return True

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -1,0 +1,192 @@
+"""Unit tests for tap_freshdesk discover module and check_stream_access helper."""
+import unittest
+from unittest.mock import MagicMock, patch
+
+from tap_freshdesk.exceptions import freshdeskUnauthorizedError, freshdeskForbiddenError
+from tap_freshdesk.utils import check_stream_access
+from tap_freshdesk.discover import _check_stream_access, discover
+from tap_freshdesk.streams import STREAMS
+
+
+# ---------------------------------------------------------------------------
+# check_stream_access (shared helper)
+# ---------------------------------------------------------------------------
+
+class TestCheckStreamAccess(unittest.TestCase):
+    """Tests for the shared check_stream_access helper in tap_freshdesk.utils."""
+
+    def test_returns_true_when_probe_succeeds(self):
+        result = check_stream_access(
+            "tickets",
+            probe_fn=lambda: None,
+            auth_error_types=(freshdeskUnauthorizedError, freshdeskForbiddenError),
+        )
+        self.assertTrue(result)
+
+    def test_returns_false_on_unauthorized_error(self):
+        def _raise():
+            raise freshdeskUnauthorizedError("401 Unauthorized")
+
+        result = check_stream_access(
+            "tickets",
+            probe_fn=_raise,
+            auth_error_types=(freshdeskUnauthorizedError, freshdeskForbiddenError),
+        )
+        self.assertFalse(result)
+
+    def test_returns_false_on_forbidden_error(self):
+        def _raise():
+            raise freshdeskForbiddenError("403 Forbidden")
+
+        result = check_stream_access(
+            "tickets",
+            probe_fn=_raise,
+            auth_error_types=(freshdeskUnauthorizedError, freshdeskForbiddenError),
+        )
+        self.assertFalse(result)
+
+    def test_re_raises_non_auth_error_when_fallback_false(self):
+        def _raise():
+            raise RuntimeError("500 Server Error")
+
+        with self.assertRaises(RuntimeError):
+            check_stream_access(
+                "tickets",
+                probe_fn=_raise,
+                auth_error_types=(freshdeskUnauthorizedError, freshdeskForbiddenError),
+                fallback_accessible=False,
+            )
+
+    def test_returns_true_on_non_auth_error_when_fallback_true(self):
+        def _raise():
+            raise RuntimeError("400 Bad Request")
+
+        result = check_stream_access(
+            "tickets",
+            probe_fn=_raise,
+            auth_error_types=(freshdeskUnauthorizedError, freshdeskForbiddenError),
+            fallback_accessible=True,
+        )
+        self.assertTrue(result)
+
+
+# ---------------------------------------------------------------------------
+# _check_stream_access (tap-specific wrapper)
+# ---------------------------------------------------------------------------
+
+class TestFreshdeskCheckStreamAccess(unittest.TestCase):
+    """Tests for the tap-freshdesk _check_stream_access wrapper in discover.py."""
+
+    def _make_client(self, side_effect=None):
+        client = MagicMock()
+        client.base_url = "https://example.freshdesk.com/api/v2"
+        if side_effect:
+            client.get.side_effect = side_effect
+        return client
+
+    def test_child_stream_always_accessible(self):
+        """Child streams (path contains '{}') are skipped and returned as True."""
+        for stream_name, stream_cls in STREAMS.items():
+            if '{}' in stream_cls.path:
+                client = self._make_client()
+                result = _check_stream_access(client, stream_name, stream_cls)
+                self.assertTrue(result, msg=f"Child stream '{stream_name}' should always be True")
+                client.get.assert_not_called()
+
+    def test_top_level_stream_returns_true_when_accessible(self):
+        client = self._make_client()
+        result = _check_stream_access(client, "tickets", STREAMS["tickets"])
+        self.assertTrue(result)
+        client.get.assert_called_once()
+
+    def test_top_level_stream_returns_false_on_401(self):
+        client = self._make_client(side_effect=freshdeskUnauthorizedError("401"))
+        result = _check_stream_access(client, "tickets", STREAMS["tickets"])
+        self.assertFalse(result)
+
+    def test_top_level_stream_returns_false_on_403(self):
+        client = self._make_client(side_effect=freshdeskForbiddenError("403"))
+        result = _check_stream_access(client, "agents", STREAMS["agents"])
+        self.assertFalse(result)
+
+    def test_top_level_stream_reraises_other_errors(self):
+        client = self._make_client(side_effect=ConnectionError("timeout"))
+        with self.assertRaises(ConnectionError):
+            _check_stream_access(client, "contacts", STREAMS["contacts"])
+
+    def test_probe_url_is_built_from_base_url_and_path(self):
+        """Verifies the endpoint passed to client.get is base_url + path."""
+        client = self._make_client()
+        stream_cls = STREAMS["tickets"]
+        _check_stream_access(client, "tickets", stream_cls)
+        call_kwargs = client.get.call_args
+        called_endpoint = call_kwargs.kwargs.get("endpoint") or call_kwargs[1].get("endpoint")
+        self.assertIn(stream_cls.path, called_endpoint)
+
+
+# ---------------------------------------------------------------------------
+# discover()
+# ---------------------------------------------------------------------------
+
+class TestDiscover(unittest.TestCase):
+    """Tests for the discover() function in tap_freshdesk.discover."""
+
+    def _minimal_schema_pair(self, stream_names):
+        schemas = {n: {"type": "object", "properties": {}} for n in stream_names}
+        meta = {n: [{"metadata": {"table-key-properties": ["id"]}, "breadcrumb": []}]
+                for n in stream_names}
+        return schemas, meta
+
+    @patch("tap_freshdesk.discover.get_schemas")
+    @patch("tap_freshdesk.discover._check_stream_access")
+    def test_all_accessible_streams_in_catalog(self, mock_check, mock_get_schemas):
+        """All streams accessible → all appear in the catalog."""
+        stream_names = list(STREAMS.keys())
+        mock_get_schemas.return_value = self._minimal_schema_pair(stream_names)
+        mock_check.return_value = True
+
+        client = MagicMock()
+        catalog = discover(client)
+        returned = {s.tap_stream_id for s in catalog.streams}
+        self.assertEqual(returned, set(stream_names))
+
+    @patch("tap_freshdesk.discover.get_schemas")
+    @patch("tap_freshdesk.discover._check_stream_access")
+    def test_inaccessible_stream_excluded(self, mock_check, mock_get_schemas):
+        """A stream returning False from access check is excluded from the catalog."""
+        stream_names = list(STREAMS.keys())
+        blocked = "agents"
+        mock_get_schemas.return_value = self._minimal_schema_pair(stream_names)
+        mock_check.side_effect = lambda client, name, cls: name != blocked
+
+        client = MagicMock()
+        catalog = discover(client)
+        returned = {s.tap_stream_id for s in catalog.streams}
+        self.assertNotIn(blocked, returned)
+        self.assertEqual(returned, set(stream_names) - {blocked})
+
+    @patch("tap_freshdesk.discover.get_schemas")
+    @patch("tap_freshdesk.discover._check_stream_access")
+    def test_all_inaccessible_returns_empty_catalog(self, mock_check, mock_get_schemas):
+        mock_get_schemas.return_value = self._minimal_schema_pair(list(STREAMS.keys()))
+        mock_check.return_value = False
+
+        client = MagicMock()
+        catalog = discover(client)
+        self.assertEqual(catalog.streams, [])
+
+    @patch("tap_freshdesk.discover.get_schemas")
+    @patch("tap_freshdesk.discover._check_stream_access")
+    def test_check_called_for_every_stream(self, mock_check, mock_get_schemas):
+        """_check_stream_access is called exactly once per stream."""
+        stream_names = list(STREAMS.keys())
+        mock_get_schemas.return_value = self._minimal_schema_pair(stream_names)
+        mock_check.return_value = True
+
+        client = MagicMock()
+        discover(client)
+        self.assertEqual(mock_check.call_count, len(stream_names))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -3,78 +3,16 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from tap_freshdesk.exceptions import freshdeskUnauthorizedError, freshdeskForbiddenError, freshdeskNoAccessibleStreamsError
-from tap_freshdesk.discover import check_stream_access, _check_stream_access, discover
+from tap_freshdesk.discover import check_stream_access, discover
 from tap_freshdesk.streams import STREAMS
 
 
 # ---------------------------------------------------------------------------
-# check_stream_access (shared helper)
+# check_stream_access
 # ---------------------------------------------------------------------------
 
 class TestCheckStreamAccess(unittest.TestCase):
-    """Tests for the shared check_stream_access helper in tap_freshdesk.discover."""
-
-    def test_returns_true_when_probe_succeeds(self):
-        result = check_stream_access(
-            "tickets",
-            probe_fn=lambda: None,
-            auth_error_types=(freshdeskUnauthorizedError, freshdeskForbiddenError),
-        )
-        self.assertTrue(result)
-
-    def test_returns_false_on_unauthorized_error(self):
-        def _raise():
-            raise freshdeskUnauthorizedError("401 Unauthorized")
-
-        result = check_stream_access(
-            "tickets",
-            probe_fn=_raise,
-            auth_error_types=(freshdeskUnauthorizedError, freshdeskForbiddenError),
-        )
-        self.assertFalse(result)
-
-    def test_returns_false_on_forbidden_error(self):
-        def _raise():
-            raise freshdeskForbiddenError("403 Forbidden")
-
-        result = check_stream_access(
-            "tickets",
-            probe_fn=_raise,
-            auth_error_types=(freshdeskUnauthorizedError, freshdeskForbiddenError),
-        )
-        self.assertFalse(result)
-
-    def test_re_raises_non_auth_error_when_fallback_false(self):
-        def _raise():
-            raise RuntimeError("500 Server Error")
-
-        with self.assertRaises(RuntimeError):
-            check_stream_access(
-                "tickets",
-                probe_fn=_raise,
-                auth_error_types=(freshdeskUnauthorizedError, freshdeskForbiddenError),
-                fallback_accessible=False,
-            )
-
-    def test_returns_true_on_non_auth_error_when_fallback_true(self):
-        def _raise():
-            raise RuntimeError("400 Bad Request")
-
-        result = check_stream_access(
-            "tickets",
-            probe_fn=_raise,
-            auth_error_types=(freshdeskUnauthorizedError, freshdeskForbiddenError),
-            fallback_accessible=True,
-        )
-        self.assertTrue(result)
-
-
-# ---------------------------------------------------------------------------
-# _check_stream_access (tap-specific wrapper)
-# ---------------------------------------------------------------------------
-
-class TestFreshdeskCheckStreamAccess(unittest.TestCase):
-    """Tests for the tap-freshdesk _check_stream_access wrapper in discover.py."""
+    """Tests for the merged check_stream_access function in tap_freshdesk.discover."""
 
     def _make_client(self, side_effect=None):
         client = MagicMock()
@@ -88,36 +26,36 @@ class TestFreshdeskCheckStreamAccess(unittest.TestCase):
         for stream_name, stream_cls in STREAMS.items():
             if '{}' in stream_cls.path:
                 client = self._make_client()
-                result = _check_stream_access(client, stream_name, stream_cls)
+                result = check_stream_access(client, stream_cls)
                 self.assertTrue(result, msg=f"Child stream '{stream_name}' should always be True")
                 client.get.assert_not_called()
 
     def test_top_level_stream_returns_true_when_accessible(self):
         client = self._make_client()
-        result = _check_stream_access(client, "tickets", STREAMS["tickets"])
+        result = check_stream_access(client, STREAMS["tickets"])
         self.assertTrue(result)
         client.get.assert_called_once()
 
     def test_top_level_stream_returns_false_on_401(self):
         client = self._make_client(side_effect=freshdeskUnauthorizedError("401"))
-        result = _check_stream_access(client, "tickets", STREAMS["tickets"])
+        result = check_stream_access(client, STREAMS["tickets"])
         self.assertFalse(result)
 
     def test_top_level_stream_returns_false_on_403(self):
         client = self._make_client(side_effect=freshdeskForbiddenError("403"))
-        result = _check_stream_access(client, "agents", STREAMS["agents"])
+        result = check_stream_access(client, STREAMS["agents"])
         self.assertFalse(result)
 
     def test_top_level_stream_reraises_other_errors(self):
         client = self._make_client(side_effect=ConnectionError("timeout"))
         with self.assertRaises(ConnectionError):
-            _check_stream_access(client, "contacts", STREAMS["contacts"])
+            check_stream_access(client, STREAMS["contacts"])
 
     def test_probe_url_is_built_from_base_url_and_path(self):
         """Verifies the endpoint passed to client.get is base_url + path."""
         client = self._make_client()
         stream_cls = STREAMS["tickets"]
-        _check_stream_access(client, "tickets", stream_cls)
+        check_stream_access(client, stream_cls)
         call_kwargs = client.get.call_args
         called_endpoint = call_kwargs.kwargs.get("endpoint") or call_kwargs[1].get("endpoint")
         self.assertIn(stream_cls.path, called_endpoint)
@@ -137,7 +75,7 @@ class TestDiscover(unittest.TestCase):
         return schemas, meta
 
     @patch("tap_freshdesk.discover.get_schemas")
-    @patch("tap_freshdesk.discover._check_stream_access")
+    @patch("tap_freshdesk.discover.check_stream_access")
     def test_all_accessible_streams_in_catalog(self, mock_check, mock_get_schemas):
         """All streams accessible → all appear in the catalog."""
         stream_names = list(STREAMS.keys())
@@ -150,13 +88,13 @@ class TestDiscover(unittest.TestCase):
         self.assertEqual(returned, set(stream_names))
 
     @patch("tap_freshdesk.discover.get_schemas")
-    @patch("tap_freshdesk.discover._check_stream_access")
+    @patch("tap_freshdesk.discover.check_stream_access")
     def test_inaccessible_stream_excluded(self, mock_check, mock_get_schemas):
         """A stream returning False from access check is excluded from the catalog."""
         stream_names = list(STREAMS.keys())
         blocked = "agents"
         mock_get_schemas.return_value = self._minimal_schema_pair(stream_names)
-        mock_check.side_effect = lambda client, name, cls: name != blocked
+        mock_check.side_effect = lambda client, cls: cls is not STREAMS[blocked]
 
         client = MagicMock()
         catalog = discover(client)
@@ -165,7 +103,7 @@ class TestDiscover(unittest.TestCase):
         self.assertEqual(returned, set(stream_names) - {blocked})
 
     @patch("tap_freshdesk.discover.get_schemas")
-    @patch("tap_freshdesk.discover._check_stream_access")
+    @patch("tap_freshdesk.discover.check_stream_access")
     def test_all_inaccessible_raises_exception(self, mock_check, mock_get_schemas):
         """When all streams are inaccessible, discover() raises freshdeskNoAccessibleStreamsError."""
         mock_get_schemas.return_value = self._minimal_schema_pair(list(STREAMS.keys()))
@@ -177,9 +115,9 @@ class TestDiscover(unittest.TestCase):
         self.assertIn("No stream endpoints are accessible", str(ctx.exception))
 
     @patch("tap_freshdesk.discover.get_schemas")
-    @patch("tap_freshdesk.discover._check_stream_access")
+    @patch("tap_freshdesk.discover.check_stream_access")
     def test_check_called_for_every_stream(self, mock_check, mock_get_schemas):
-        """_check_stream_access is called exactly once per stream."""
+        """check_stream_access is called exactly once per stream."""
         stream_names = list(STREAMS.keys())
         mock_get_schemas.return_value = self._minimal_schema_pair(stream_names)
         mock_check.return_value = True

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -112,7 +112,7 @@ class TestDiscover(unittest.TestCase):
         client = MagicMock()
         with self.assertRaises(freshdeskNoAccessibleStreamsError) as ctx:
             discover(client)
-        self.assertIn("No stream endpoints are accessible", str(ctx.exception))
+        self.assertIn("The credentials do not have read access to any of the supported streams", str(ctx.exception))
 
     @patch("tap_freshdesk.discover.get_schemas")
     @patch("tap_freshdesk.discover.check_stream_access")

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -2,9 +2,8 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-from tap_freshdesk.exceptions import freshdeskUnauthorizedError, freshdeskForbiddenError
-from tap_freshdesk.utils import check_stream_access
-from tap_freshdesk.discover import _check_stream_access, discover
+from tap_freshdesk.exceptions import freshdeskUnauthorizedError, freshdeskForbiddenError, freshdeskNoAccessibleStreamsError
+from tap_freshdesk.discover import check_stream_access, _check_stream_access, discover
 from tap_freshdesk.streams import STREAMS
 
 
@@ -13,7 +12,7 @@ from tap_freshdesk.streams import STREAMS
 # ---------------------------------------------------------------------------
 
 class TestCheckStreamAccess(unittest.TestCase):
-    """Tests for the shared check_stream_access helper in tap_freshdesk.utils."""
+    """Tests for the shared check_stream_access helper in tap_freshdesk.discover."""
 
     def test_returns_true_when_probe_succeeds(self):
         result = check_stream_access(
@@ -167,13 +166,15 @@ class TestDiscover(unittest.TestCase):
 
     @patch("tap_freshdesk.discover.get_schemas")
     @patch("tap_freshdesk.discover._check_stream_access")
-    def test_all_inaccessible_returns_empty_catalog(self, mock_check, mock_get_schemas):
+    def test_all_inaccessible_raises_exception(self, mock_check, mock_get_schemas):
+        """When all streams are inaccessible, discover() raises freshdeskNoAccessibleStreamsError."""
         mock_get_schemas.return_value = self._minimal_schema_pair(list(STREAMS.keys()))
         mock_check.return_value = False
 
         client = MagicMock()
-        catalog = discover(client)
-        self.assertEqual(catalog.streams, [])
+        with self.assertRaises(freshdeskNoAccessibleStreamsError) as ctx:
+            discover(client)
+        self.assertIn("No stream endpoints are accessible", str(ctx.exception))
 
     @patch("tap_freshdesk.discover.get_schemas")
     @patch("tap_freshdesk.discover._check_stream_access")


### PR DESCRIPTION
# Description of change
## Summary

Added stream-level access checks during discovery to detect authentication and permission issues early, before sync begins. Inaccessible streams are excluded from the catalog with a warning rather than failing silently at sync time.

## Changes

### New: `check_stream_access` utility function
A standardised helper added to each tap's utility/helper module (`utils.py` / `helpers.py`):
- Accepts a `probe_fn` (zero-argument callable), `auth_error_types`, and an optional `fallback_accessible` flag
- Returns `True` if the stream is accessible, `False` on auth errors (401/403), and re-raises unexpected errors unless `fallback_accessible=True`
- Fully reusable across taps — each tap only needs to supply its own exception types and probe callable

### tap-freshdesk
- `discover()` now accepts a `client` argument (previously no client was passed)
- Each top-level stream is probed with `GET /{path}?per_page=1&page=1` before being added to the catalog
- Child streams (`conversations`, `satisfaction_ratings`, `time_entries`) whose path contains `{}` are skipped — they cannot be probed without a parent ID and are assumed accessible
- Streams returning `freshdeskUnauthorizedError` or `freshdeskForbiddenError` are excluded from the catalog with a `WARNING` log
- `do_discover()` in `__init__.py` updated to pass the `client` object

### Tests
- New `tests/unittests/test_discover.py` added to each tap covering:
  - `check_stream_access`: success, auth error → False, non-auth error handling, tuple of auth types, `fallback_accessible` flag
  - Tap-specific `_check_stream_access`: child stream bypass, correct probe params, 401/403 → False, other errors re-raised
  - `discover()`: missing config, all accessible, one blocked, all blocked → empty catalog, correct call count per stream

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
