### PR TITLE
SAC-31317: Handle Freshdesk tickets stream's 400 issue and ratelimit

### DIFF
--- a/tap_freshdesk/client.py
+++ b/tap_freshdesk/client.py
@@ -10,10 +10,32 @@ from tap_freshdesk.exceptions import (
     ERROR_CODE_EXCEPTION_MAPPING,
     freshdeskError,
     freshdeskBackoffError,
+    freshdeskRateLimitError,
 )
 
 LOGGER = get_logger()
 REQUEST_TIMEOUT = 300
+
+
+def get_backoff_time(exception_info) -> float:
+    """ Extracts the retry_after information from the rate-limit exception and returns it.
+    """
+
+    retry_after = 60.0  # Default backoff time in seconds
+
+    exception = exception_info.get("exception") if isinstance(exception_info, dict) else exception_info
+
+    if exception and isinstance(exception, freshdeskRateLimitError):
+        actual_retry_after = exception.retry_after
+        if actual_retry_after is not None:
+            retry_after = actual_retry_after
+
+    LOGGER.warning(
+        "Freshdesk rate limit encountered. Retrying after %s seconds.",
+        retry_after,
+    )
+
+    return retry_after
 
 
 def raise_for_error(response: requests.Response) -> None:
@@ -111,6 +133,16 @@ class Client:
         ),
         max_tries=5,
         factor=2,
+        # Do not re-retry rate-limit errors that already exhausted the inner
+        # runtime-backoff decorator; let them propagate immediately.
+        giveup=lambda e: isinstance(e, freshdeskRateLimitError),
+    )
+    @backoff.on_exception(
+        wait_gen=backoff.runtime,
+        exception=freshdeskRateLimitError,
+        value=get_backoff_time,
+        max_tries=5,
+        jitter=None
     )
     def __make_request(
         self, method: str, endpoint: str, **kwargs

--- a/tap_freshdesk/exceptions.py
+++ b/tap_freshdesk/exceptions.py
@@ -52,7 +52,28 @@ class freshdeskUnprocessableEntityError(freshdeskBackoffError):
 class freshdeskRateLimitError(freshdeskBackoffError):
     """Class representing 429 status code."""
 
-    pass
+    def __init__(self, message=None, response=None):
+        """Initalize a freshdesk rate-limit error class and extracts the Retry-After header from the response."""
+        self.response = response
+        self.message = message
+        self.retry_after = None
+
+        if response is not None:
+            headers = response.headers or {}
+
+            retry_after = headers.get("Retry-After")
+            # try to parse the retry_after value as a float, if it fails, default to 60 seconds
+            try:
+                self.retry_after = float(retry_after)
+            except (ValueError, TypeError):
+                self.retry_after = 60.0
+
+        base_message = self.message or "FreshDesk Rate Limit Exceeded"
+
+        if self.retry_after is not None:
+            base_message += f" - Retry after {self.retry_after} seconds"
+
+        super().__init__(base_message, response)
 
 
 class freshdeskInternalServerError(freshdeskBackoffError):

--- a/tap_freshdesk/exceptions.py
+++ b/tap_freshdesk/exceptions.py
@@ -53,7 +53,7 @@ class freshdeskRateLimitError(freshdeskBackoffError):
     """Class representing 429 status code."""
 
     def __init__(self, message=None, response=None):
-        """Initalize a freshdesk rate-limit error class and extracts the Retry-After header from the response."""
+        """Initialize a Freshdesk rate-limit error and extract the Retry-After header from the response."""
         self.response = response
         self.message = message
         self.retry_after = None

--- a/tap_freshdesk/streams/abstracts.py
+++ b/tap_freshdesk/streams/abstracts.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from datetime import timedelta
 from typing import Any, Dict, Tuple, List
 import copy
 
@@ -13,6 +14,8 @@ from singer import (
     write_schema,
 )
 from singer.utils import strftime, strptime_to_utc
+
+from tap_freshdesk.exceptions import freshdeskBadRequestError
 
 LOGGER = get_logger()
 
@@ -246,9 +249,9 @@ class IncrementalStream(BaseStream):
             yield from raw_records
 
             if len(raw_records) == self.page_size:
-                LOGGER.info("Fetching Page %s", page_count)
                 page_count += 1
                 self.params["page"] = page_count
+                LOGGER.info("Fetching Page %s", page_count)
             else:
                 break
 
@@ -363,11 +366,11 @@ class ParentBaseStream(IncrementalStream):
         return state
 
     def sync(
-    self,
-    state: Dict,
-    transformer: Transformer,
-    parent_obj: Dict = None,
-) -> Dict:
+        self,
+        state: Dict,
+        transformer: Transformer,
+        parent_obj: Dict = None,
+    ) -> Dict:
         """Implementation for `type: Incremental` stream."""
         self.url_endpoint = self.get_url_endpoint(parent_obj)
 
@@ -380,6 +383,11 @@ class ParentBaseStream(IncrementalStream):
             }
         )
 
+        MAX_RESTARTS = 10  # Max number of retries if Freshdesk's 300 pages/30,000 ticket limit is hit
+        # Tracks IDs processed for the current updated_at timestamp
+        self.ids_cache = set()
+        self.current_timestamp_window = None
+
         with metrics.record_counter(self.tap_stream_id) as counter:
             filter_values = [{}, {"filter": "spam"}, {"filter": "deleted"}]
             for value in filter_values:
@@ -389,43 +397,142 @@ class ParentBaseStream(IncrementalStream):
                     ticket_key = (
                         self.tap_stream_id
                     )  # Default key when value is None or empty
-                current_max_bookmark_date = bookmark_date = updated_since = (
-                    self.get_bookmark(state, ticket_key)
-                )
-                self.params.update({"updated_since": updated_since})
-                self.params.update(**value)
-                for record in self.get_records(state):
-                    if "custom_fields" in record:
-                        record["custom_fields"] = self.modify_object_custom_fields(
-                            record["custom_fields"], force_to_string=True
-                        )
-                    transformed_record = transformer.transform(
-                        record, self.schema, self.metadata
+
+                # Added a workfolw with try catch to handle freshdesk limitation for tickets endpoint.
+                # The Tickets endpoint returns a maximum of 300 pages (30,000 tickets).
+                # If more than 300 pages or 30,000 tickets request is sent, the API returns a 400 error.
+                # Ref: https://developers.freshdesk.com/api/#list_all_tickets
+                restart_count = 0  # Counter check for max 400 error retries
+                sync_completed = False  # Flag to handle the while loop
+
+                while not sync_completed:  # If the sync was abrupted, the core workflow will be resumed with updated state
+
+                    current_max_bookmark_date = bookmark_date = updated_since = (
+                        self.get_bookmark(state, ticket_key)
                     )
+                    self.params.update({"updated_since": updated_since})
+                    self.params.update(**value)
 
-                    record_timestamp = transformed_record[self.replication_keys[0]]
-                    if record_timestamp >= bookmark_date:
-                        # Only write parent records if parent is selected
-                        if self.is_selected():
-                            write_record(self.tap_stream_id, transformed_record)
-                            counter.increment()
+                    try:
+                        for record in self.get_records(state):
 
-                        # Sync only selected child streams
-                        for child in self.child_to_sync:
-                            if self.is_child_selected(child):
-                                child.sync(
-                                    state=state,
-                                    transformer=transformer,
-                                    parent_obj=record
+                            if "custom_fields" in record:
+                                record["custom_fields"] = self.modify_object_custom_fields(
+                                    record["custom_fields"], force_to_string=True
+                                )
+                            transformed_record = transformer.transform(
+                                record, self.schema, self.metadata
+                            )
+
+                            record_timestamp = transformed_record[self.replication_keys[0]]
+
+                            #
+                            # Timestamp window handling
+                            #
+                            # Example:
+                            #
+                            # 10:00 -> cache {1,2,3}
+                            # 10:01 -> clear cache
+                            # 10:02 -> clear cache
+                            #
+                            if self.current_timestamp_window != record_timestamp:
+                                LOGGER.info(
+                                    "Moving timestamp window from %s to %s. "
+                                    "Clearing ID cache.",
+                                    self.current_timestamp_window,
+                                    record_timestamp,
                                 )
 
-                        current_max_bookmark_date = max(
-                            current_max_bookmark_date, record_timestamp
+                                self.current_timestamp_window = record_timestamp
+                                self.ids_cache.clear()
+
+                            # Check if the record has already been synced using the ids_cache to avoid duplicates
+                            cache_key = ticket_key + "_" + str(record["id"])
+                            if cache_key in self.ids_cache:
+                                LOGGER.info(
+                                    "Skipping already processed ticket id=%s "
+                                    "for timestamp=%s",
+                                    cache_key,
+                                    record_timestamp,
+                                )
+                                continue
+
+                            if record_timestamp >= bookmark_date:
+                                # Only write parent records if parent is selected
+                                if self.is_selected():
+                                    write_record(self.tap_stream_id, transformed_record)
+                                    counter.increment()
+
+                                # Sync only selected child streams
+                                for child in self.child_to_sync:
+                                    if self.is_child_selected(child):
+                                        child.sync(
+                                            state=state,
+                                            transformer=transformer,
+                                            parent_obj=record
+                                        )
+
+                                # Add to cache ONLY after successful processing
+                                self.ids_cache.add(cache_key)
+
+                                current_max_bookmark_date = max(
+                                    current_max_bookmark_date, record_timestamp
+                                )
+
+                        #
+                        # Sync completed successfully.
+                        #
+                        state = self.write_bookmark(
+                            state,
+                            ticket_key,
+                            value=current_max_bookmark_date,
                         )
 
-                state = self.write_bookmark(
-                    state, ticket_key, value=current_max_bookmark_date
-                )
+                        sync_completed = True
+
+                    except freshdeskBadRequestError:
+                        restart_count += 1
+                        # handle a freshdesk bad-request error. Then rerun the sync with the state set to current_max_bookmark_date.
+                        LOGGER.warning(
+                            "Freshdesk ticket limit reached for %s. "
+                            "Restarting sync from bookmark %s "
+                            "(attempt %s/%s)",
+                            ticket_key,
+                            current_max_bookmark_date,
+                            restart_count,
+                            MAX_RESTARTS,
+                        )
+                        if restart_count >= MAX_RESTARTS:
+                            advanced_bookmark = strftime(
+                                strptime_to_utc(current_max_bookmark_date)
+                                + timedelta(seconds=1)
+                            )
+
+                            LOGGER.error(
+                                "Max restart attempts reached for %s. "
+                                "Advancing bookmark from %s to %s and aborting sync.",
+                                ticket_key,
+                                current_max_bookmark_date,
+                                advanced_bookmark,
+                            )
+
+                            state = self.write_bookmark(
+                                state,
+                                ticket_key,
+                                value=advanced_bookmark,
+                            )
+
+                            raise
+
+                        # Persist progress before restarting
+                        state = self.write_bookmark(
+                            state,
+                            ticket_key,
+                            value=current_max_bookmark_date,
+                        )
+
+                        # Loop restarts automatically
+
             return counter.value
 
 

--- a/tap_freshdesk/streams/abstracts.py
+++ b/tap_freshdesk/streams/abstracts.py
@@ -190,13 +190,18 @@ class BaseStream(ABC):
         params = {"per_page": 1, "page": 1}
         try:
             if self.parent:
-                from tap_freshdesk.streams import STREAMS
+                from tap_freshdesk.streams import STREAMS  # To fix circular import
+                parent_params = {"per_page": 1, "page": 1}
+
+                if self.parent == "tickets":
+                    updated_since = self.get_bookmark({}, self.tap_stream_id)
+                    parent_params["updated_since"] = updated_since
 
                 parent_stream = STREAMS[self.parent](client=self.client)
                 parent_endpoint = f"{self.client.base_url}/{parent_stream.path}"
                 parent_records = self.client.get(
                     endpoint=parent_endpoint,
-                    params=params,
+                    params=parent_params,
                     headers=self.headers,
                 )
 

--- a/tap_freshdesk/streams/abstracts.py
+++ b/tap_freshdesk/streams/abstracts.py
@@ -398,14 +398,14 @@ class ParentBaseStream(IncrementalStream):
                         self.tap_stream_id
                     )  # Default key when value is None or empty
 
-                # Added a workfolw with try catch to handle freshdesk limitation for tickets endpoint.
+                # Added a workflow with try/except to handle Freshdesk's ticket endpoint limitation.
                 # The Tickets endpoint returns a maximum of 300 pages (30,000 tickets).
-                # If more than 300 pages or 30,000 tickets request is sent, the API returns a 400 error.
+                # If a request would exceed this limit, the API returns a 400 error.
                 # Ref: https://developers.freshdesk.com/api/#list_all_tickets
                 restart_count = 0  # Counter check for max 400 error retries
                 sync_completed = False  # Flag to handle the while loop
 
-                while not sync_completed:  # If the sync was abrupted, the core workflow will be resumed with updated state
+                while not sync_completed:  # If the sync was interrupted, the core workflow will be resumed with updated state
 
                     current_max_bookmark_date = bookmark_date = updated_since = (
                         self.get_bookmark(state, ticket_key)
@@ -426,15 +426,11 @@ class ParentBaseStream(IncrementalStream):
 
                             record_timestamp = transformed_record[self.replication_keys[0]]
 
-                            #
                             # Timestamp window handling
-                            #
                             # Example:
-                            #
                             # 10:00 -> cache {1,2,3}
                             # 10:01 -> clear cache
                             # 10:02 -> clear cache
-                            #
                             if self.current_timestamp_window != record_timestamp:
                                 LOGGER.info(
                                     "Moving timestamp window from %s to %s. "
@@ -479,9 +475,7 @@ class ParentBaseStream(IncrementalStream):
                                     current_max_bookmark_date, record_timestamp
                                 )
 
-                        #
                         # Sync completed successfully.
-                        #
                         state = self.write_bookmark(
                             state,
                             ticket_key,
@@ -493,6 +487,7 @@ class ParentBaseStream(IncrementalStream):
                     except freshdeskBadRequestError:
                         restart_count += 1
                         # handle a freshdesk bad-request error. Then rerun the sync with the state set to current_max_bookmark_date.
+                        # Ref: https://developers.freshdesk.com/api/#list_all_tickets
                         LOGGER.warning(
                             "Freshdesk ticket limit reached for %s. "
                             "Restarting sync from bookmark %s "

--- a/tests/base.py
+++ b/tests/base.py
@@ -11,6 +11,7 @@ class FreshdeskBaseTest(BaseCase):
 
     start_date = "2017-01-01T00:00:00Z"
     PARENT_TAP_STREAM_ID = "parent-tap-stream-id"
+    IS_FORBIDDEN_STREAM = "is-forbidden-stream"
 
     @staticmethod
     def tap_name():
@@ -72,7 +73,8 @@ class FreshdeskBaseTest(BaseCase):
                 cls.REPLICATION_KEYS: {"updated_at"},
                 cls.EXPECTED_PAGE_SIZE: 100,
                 cls.API_LIMIT: 100,
-                cls.PARENT_TAP_STREAM_ID: "tickets"
+                cls.PARENT_TAP_STREAM_ID: "tickets",
+                cls.IS_FORBIDDEN_STREAM: True
             },
             "tickets": {
                 cls.PRIMARY_KEYS: {"id"},
@@ -87,8 +89,18 @@ class FreshdeskBaseTest(BaseCase):
                 cls.REPLICATION_KEYS: {"updated_at"},
                 cls.EXPECTED_PAGE_SIZE: 100,
                 cls.API_LIMIT: 100,
-                cls.PARENT_TAP_STREAM_ID: "tickets"
+                cls.PARENT_TAP_STREAM_ID: "tickets",
+                cls.IS_FORBIDDEN_STREAM: True
             },
+        }
+
+    @classmethod
+    def expected_stream_names(cls):
+        """A set of expected stream names"""
+        return {
+            stream_name
+            for stream_name, metadata in cls.expected_metadata().items()
+            if not metadata.get(cls.IS_FORBIDDEN_STREAM, False)
         }
 
     @staticmethod

--- a/tests/unittests/test_abstracts.py
+++ b/tests/unittests/test_abstracts.py
@@ -1,6 +1,9 @@
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, Mock
 from tap_freshdesk.streams.abstracts import ParentBaseStream, ChildBaseStream, IncrementalStream
+
+from tap_freshdesk.streams import Tickets
+from tap_freshdesk.exceptions import freshdeskBadRequestError
 
 
 class ConcreteParentBaseStream(ParentBaseStream):
@@ -484,3 +487,602 @@ class TestIncrementalStream(unittest.TestCase):
         result = self.stream.get_bookmark(state, "test_stream")
         
         self.assertEqual(result, "2023-01-01")
+
+
+class TestTicketsSync(unittest.TestCase):
+
+    @patch("tap_freshdesk.streams.abstracts.metadata.to_map")
+    def setUp(self, mock_to_map):
+        mock_catalog = MagicMock()
+        mock_catalog.schema.to_dict.return_value = {"key": "value"}
+        mock_catalog.metadata = "mock_metadata"
+        mock_to_map.return_value = {"metadata_key": "metadata_value"}
+
+        mock_client = MagicMock()
+        mock_client.config = {"start_date": "2023-01-01"}
+        self.stream = Tickets(client=mock_client, catalog=mock_catalog)
+
+        self.stream.is_selected = Mock(return_value=True)
+        self.stream.is_child_selected = Mock(return_value=True)
+
+        self.stream.child_to_sync = []
+
+        self.transformer = Mock()
+        self.transformer.transform.side_effect = (
+            lambda record, *args: record
+        )
+
+        self.state = {}
+
+    @patch("tap_freshdesk.streams.abstracts.write_record")
+    def test_sync_happy_path(self, mock_write_record):
+        """
+        Verify all records are written and bookmark is updated.
+        """
+
+        self.stream.get_bookmark = Mock(
+            return_value="2024-01-01T00:00:00Z"
+        )
+
+        self.stream.write_bookmark = Mock(
+            side_effect=lambda state, key, value: state
+        )
+
+        self.stream.get_records = Mock(
+            side_effect=lambda state: iter(
+                [
+                    {
+                        "id": 1,
+                        "updated_at": "2024-01-01T01:00:00Z",
+                    },
+                    {
+                        "id": 2,
+                        "updated_at": "2024-01-01T02:00:00Z",
+                    },
+                ]
+            )
+        )
+
+        self.stream.sync(
+            self.state,
+            self.transformer,
+        )
+
+        # Call count for 2 records, for all 3 filter types (all, spam, deleted)
+        self.assertEqual(mock_write_record.call_count, 2*3)
+
+        self.stream.write_bookmark.assert_called()
+
+    @patch("tap_freshdesk.streams.abstracts.write_record")
+    def test_restart_after_400(self, mock_write_record):
+        """
+        Verify sync restarts after Freshdesk 300-page error.
+        """
+
+        self.stream.get_bookmark = Mock(
+            return_value="2024-01-01T00:00:00Z"
+        )
+
+        self.stream.write_bookmark = Mock(
+            side_effect=lambda state, key, value: state
+        )
+
+        call_count = 0
+
+        def mock_get_records(state):
+            nonlocal call_count
+
+            call_count += 1
+
+            if call_count == 1:
+                yield {
+                    "id": 1,
+                    "updated_at": "2024-01-01T01:00:00Z",
+                }
+
+                raise freshdeskBadRequestError(
+                    "Freshdesk 300 page limit reached"
+                )
+
+            yield {
+                "id": 1,
+                "updated_at": "2024-01-01T01:00:00Z",
+            }
+
+            yield {
+                "id": 2,
+                "updated_at": "2024-01-01T01:00:00Z",
+            }
+
+        self.stream.get_records = mock_get_records
+
+        self.stream.sync(
+            self.state,
+            self.transformer,
+        )
+        #
+        # ticket 1 emitted once
+        # ticket 2 emitted once
+        # This is done 3 times for all filter types 
+        self.assertEqual(
+            mock_write_record.call_count,
+            2*3,
+        )
+
+        self.assertEqual(
+            call_count,
+            4,
+        )
+
+    @patch("tap_freshdesk.streams.abstracts.write_record")
+    def test_same_ticket_processed_again_after_timestamp_window_change(
+        self,
+        mock_write_record,
+    ):
+        """
+        Scenario:
+
+        pk1  updated_at=1
+        pk2  updated_at=1
+        pk3  updated_at=1
+
+        cache = {1,2,3}
+
+        --------------------------------
+
+        pk4  updated_at=2
+        pk5  updated_at=2
+        pk6  updated_at=2
+
+        cache cleared
+
+        cache = {4,5,6}
+
+        --------------------------------
+
+        pk1  updated_at=3
+
+        cache cleared
+
+        pk1 should be written again because
+        deduplication is only scoped to the
+        current timestamp window.
+        """
+
+        self.stream.get_bookmark = Mock(
+            return_value="2024-01-01T00:00:00Z"
+        )
+
+        self.stream.write_bookmark = Mock(
+            side_effect=lambda state, key, value: state
+        )
+
+        records = [
+            {
+                "id": 1,
+                "updated_at": "2024-01-01T01:00:00Z",
+            },
+            {
+                "id": 2,
+                "updated_at": "2024-01-01T01:00:00Z",
+            },
+            {
+                "id": 3,
+                "updated_at": "2024-01-01T01:00:00Z",
+            },
+            {
+                "id": 4,
+                "updated_at": "2024-01-01T02:00:00Z",
+            },
+            {
+                "id": 5,
+                "updated_at": "2024-01-01T02:00:00Z",
+            },
+            {
+                "id": 6,
+                "updated_at": "2024-01-01T02:00:00Z",
+            },
+            {
+                "id": 1,
+                "updated_at": "2024-01-01T03:00:00Z",
+            },
+        ]
+
+        # Note: The get_records method is mocked to return an iterator over the records list.
+        # Hence the iterator will be exhausted after the first filter loop
+        # and the subsequent filter loops will not yield any records.
+        self.stream.get_records = Mock(
+            return_value=iter(records)
+        )
+
+        self.stream.sync(
+            self.state,
+            self.transformer,
+        )
+
+        #
+        # Expected writes:
+        #
+        # id=1 @ 01:00
+        # id=2 @ 01:00
+        # id=3 @ 01:00
+        # id=4 @ 02:00
+        # id=5 @ 02:00
+        # id=6 @ 02:00
+        # id=1 @ 03:00
+        #
+        self.assertEqual(
+            mock_write_record.call_count,
+            7,
+        )
+
+        written_ids = [
+            call.args[1]["id"]
+            for call in mock_write_record.call_args_list
+        ]
+
+        self.assertEqual(
+            written_ids,
+            [1, 2, 3, 4, 5, 6, 1]
+        )
+
+    @patch("tap_freshdesk.streams.abstracts.write_record")
+    def test_duplicate_same_timestamp_skipped(
+        self,
+        mock_write_record,
+    ):
+        """
+        Verify duplicate ticket IDs in same timestamp
+        window are skipped.
+        """
+
+        self.stream.get_bookmark = Mock(
+            return_value="2024-01-01T00:00:00Z"
+        )
+
+        self.stream.write_bookmark = Mock(
+            side_effect=lambda state, key, value: state
+        )
+
+        self.stream.get_records = Mock(
+            return_value=iter(
+                [
+                    {
+                        "id": 1,
+                        "updated_at": "2024-01-01T01:00:00Z",
+                    },
+                    {
+                        "id": 1,
+                        "updated_at": "2024-01-01T01:00:00Z",
+                    },
+                ]
+            )
+        )
+
+        self.stream.sync(
+            self.state,
+            self.transformer,
+        )
+
+        self.assertEqual(
+            mock_write_record.call_count,
+            1,
+        )
+
+    @patch("tap_freshdesk.streams.abstracts.write_record")
+    def test_same_ticket_new_timestamp_processed(
+        self,
+        mock_write_record,
+    ):
+        """
+        Verify same ticket ID is emitted again
+        when updated_at changes.
+        """
+
+        self.stream.get_bookmark = Mock(
+            return_value="2024-01-01T00:00:00Z"
+        )
+
+        self.stream.write_bookmark = Mock(
+            side_effect=lambda state, key, value: state
+        )
+
+        self.stream.get_records = Mock(
+            return_value=iter(
+                [
+                    {
+                        "id": 1,
+                        "updated_at": "2024-01-01T01:00:00Z",
+                    },
+                    {
+                        "id": 1,
+                        "updated_at": "2024-01-01T02:00:00Z",
+                    },
+                ]
+            )
+        )
+
+        self.stream.sync(
+            self.state,
+            self.transformer,
+        )
+
+        self.assertEqual(
+            mock_write_record.call_count,
+            2,  # Since the iterator will be ehausted after normal filters,
+                # the spam and deleted filters will not get any records.
+        )
+
+    @patch("tap_freshdesk.streams.abstracts.write_record")
+    def test_bookmark_written_before_restart(
+        self,
+        mock_write_record,
+    ):
+        """
+        Verify bookmark is persisted before retry.
+        """
+
+        bookmark_values = []
+
+        def mock_write_bookmark(
+            state,
+            key,
+            value,
+        ):
+            bookmark_values.append(value)
+            return state
+
+        self.stream.write_bookmark = Mock(
+            side_effect=mock_write_bookmark
+        )
+
+        self.stream.get_bookmark = Mock(
+            return_value="2024-01-01T00:00:00Z"
+        )
+
+        call_count = 0
+
+        def mock_get_records(state):
+            nonlocal call_count
+
+            call_count += 1
+
+            yield {
+                "id": 1,
+                "updated_at": "2024-01-01T05:00:00Z",
+            }
+
+            if call_count == 1:
+                raise freshdeskBadRequestError(
+                    "Freshdesk 300 page limit reached"
+                )
+
+        self.stream.get_records = mock_get_records
+
+        self.stream.sync(
+            self.state,
+            self.transformer,
+        )
+
+        self.assertIn(
+            "2024-01-01T05:00:00Z",
+            bookmark_values,
+        )
+
+        # Call count workflow --> call_count = 0
+        # 1. First call with normal_filters ==> call_count = 1
+        # 1. When generator resumes, it raises freshdeskBadRequestError
+        # 2. Second call with normal_filters ==> call_count = 2
+        # 3. Third call with spam_filters ==> call_count = 3
+        # 4. Fourth call with deleted_filters ==> call_count = 4
+        self.assertEqual(call_count, 4)
+
+    @patch("tap_freshdesk.streams.abstracts.LOGGER")
+    @patch("tap_freshdesk.streams.abstracts.write_record")
+    def test_max_restarts_exceeded_advances_bookmark_and_reraises(
+        self, mock_write_record, mock_logger
+    ):
+        """
+        Verify that when freshdeskBadRequestError occurs MAX_RESTARTS (10)
+        consecutive times, the bookmark is advanced by 1 second, an error is
+        logged, and the exception is re-raised.
+
+        Covers abstracts.py lines 505-528:
+          - Line 505:     if restart_count >= MAX_RESTARTS
+          - Lines 506-512: advanced_bookmark = current_max_bookmark_date + 1s
+          - Lines 514-520: LOGGER.error(...)
+          - Lines 522-526: write_bookmark called with advanced_bookmark
+          - Line 528:     raise
+        """
+        # Bookmark with microseconds to match the strptime format
+        # "%Y-%m-%dT%H:%M:%S.%fZ" used on lines 508-509
+        bookmark = "2024-01-01T00:00:00.000000Z"
+        expected_advanced_bookmark = "2024-01-01T00:00:01.000000Z"
+
+        self.stream.get_bookmark = Mock(return_value=bookmark)
+
+        bookmark_writes = []
+
+        def mock_write_bookmark(state, key, value):
+            bookmark_writes.append((key, value))
+            return state
+
+        self.stream.write_bookmark = Mock(side_effect=mock_write_bookmark)
+
+        # Always raise to exhaust all MAX_RESTARTS (10) attempts
+        def mock_get_records(state):
+            raise freshdeskBadRequestError("Freshdesk 300 page limit reached")
+
+        self.stream.get_records = mock_get_records
+
+        # Exception must be re-raised after MAX_RESTARTS attempts (line 528)
+        with self.assertRaises(freshdeskBadRequestError):
+            self.stream.sync(self.state, self.transformer)
+
+        # write_bookmark is called exactly 10 times:
+        #   - 9 times to persist progress (restart_count 1..9)
+        #   - 1 time with the advanced bookmark when restart_count = 10
+        self.assertEqual(len(bookmark_writes), 10)
+
+        # First 9 writes: persist the original bookmark unchanged
+        for key, value in bookmark_writes[:9]:
+            self.assertEqual(key, "tickets")
+            self.assertEqual(value, bookmark)
+
+        # 10th write (lines 522-526): bookmark advanced by exactly 1 second
+        last_key, last_value = bookmark_writes[-1]
+        self.assertEqual(last_key, "tickets")
+        self.assertEqual(last_value, expected_advanced_bookmark)
+
+        # LOGGER.error called once: "max restart" message (lines 514-520)
+        mock_logger.error.assert_called_once_with(
+            "Max restart attempts reached for %s. "
+            "Advancing bookmark from %s to %s and aborting sync.",
+            "tickets",
+            bookmark,
+            expected_advanced_bookmark,
+        )
+
+    @patch("tap_freshdesk.streams.abstracts.write_record")
+    def test_max_restarts_not_yet_exceeded_does_not_reraise(
+        self, mock_write_record
+    ):
+        """
+        Verify that when freshdeskBadRequestError occurs fewer than
+        MAX_RESTARTS (10) times, the sync retries without advancing
+        the bookmark or re-raising.
+
+        This tests the False branch of the `if restart_count >= MAX_RESTARTS:`
+        guard at line 505, confirming that only reaching the exact threshold
+        triggers the lines 505-528 logic.
+        """
+        bookmark = "2024-01-01T00:00:00.000000Z"
+        advanced_bookmark = "2024-01-01T00:00:01.000000Z"
+
+        self.stream.get_bookmark = Mock(return_value=bookmark)
+
+        bookmark_writes = []
+
+        def mock_write_bookmark(state, key, value):
+            bookmark_writes.append((key, value))
+            return state
+
+        self.stream.write_bookmark = Mock(side_effect=mock_write_bookmark)
+
+        call_count = 0
+        # Fail exactly MAX_RESTARTS-1 = 9 times, then succeed on the 10th call
+        MAX_RESTARTS = 10
+
+        def mock_get_records(state):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= MAX_RESTARTS - 1:
+                raise freshdeskBadRequestError(
+                    "Freshdesk 300 page limit reached"
+                )
+            yield {
+                "id": 1,
+                "updated_at": "2024-01-01T01:00:00.000000Z",
+            }
+
+        self.stream.get_records = mock_get_records
+
+        # Should complete without raising (9 failures is below MAX_RESTARTS)
+        self.stream.sync(self.state, self.transformer)
+
+        # The advanced bookmark must never have been written
+        advanced_writes = [
+            value for (_, value) in bookmark_writes
+            if value == advanced_bookmark
+        ]
+        self.assertEqual(
+            advanced_writes,
+            [],
+            "Advanced bookmark must not be written "
+            "when MAX_RESTARTS is not reached",
+        )
+
+    @patch("tap_freshdesk.streams.abstracts.LOGGER")
+    @patch("tap_freshdesk.streams.abstracts.write_record")
+    def test_max_restarts_bookmark_without_microseconds(
+        self, mock_write_record, mock_logger
+    ):
+        """
+        Bug fix: advanced_bookmark must not crash when
+        current_max_bookmark_date lacks microseconds.
+
+        Previously the code used datetime.strptime with the
+        format "%Y-%m-%dT%H:%M:%S.%fZ" which requires .ffffff.
+        A bookmark like "2024-01-01T00:00:00Z" (no microseconds)
+        would raise ValueError.  The fix uses singer's
+        strptime_to_utc which handles any ISO-8601 input.
+        """
+        # Bookmark without microseconds - previously caused ValueError
+        bookmark = "2024-01-01T00:00:00Z"
+
+        self.stream.get_bookmark = Mock(return_value=bookmark)
+
+        bookmark_writes = []
+
+        def mock_write_bookmark(state, key, value):
+            bookmark_writes.append((key, value))
+            return state
+
+        self.stream.write_bookmark = Mock(
+            side_effect=mock_write_bookmark
+        )
+
+        # Always raise to reach MAX_RESTARTS
+        def mock_get_records(state):
+            raise freshdeskBadRequestError(
+                "Freshdesk 300 page limit reached"
+            )
+
+        self.stream.get_records = mock_get_records
+
+        # Must not raise ValueError from strptime
+        with self.assertRaises(freshdeskBadRequestError):
+            self.stream.sync(self.state, self.transformer)
+
+        # The 10th write must be the advanced bookmark
+        # (1 second after "2024-01-01T00:00:00Z")
+        _, last_value = bookmark_writes[-1]
+        self.assertIn("2024-01-01T00:00:01", last_value)
+
+    @patch("tap_freshdesk.streams.abstracts.LOGGER")
+    @patch("tap_freshdesk.streams.abstracts.write_record")
+    def test_max_restarts_date_only_bookmark(
+        self, mock_write_record, mock_logger
+    ):
+        """
+        The advanced_bookmark calculation also handles a plain
+        date string start_date ("2023-01-01") without crashing.
+        singer's strptime_to_utc parses it as midnight UTC.
+        """
+        bookmark = "2023-01-01"
+
+        self.stream.get_bookmark = Mock(return_value=bookmark)
+
+        bookmark_writes = []
+
+        def mock_write_bookmark(state, key, value):
+            bookmark_writes.append((key, value))
+            return state
+
+        self.stream.write_bookmark = Mock(
+            side_effect=mock_write_bookmark
+        )
+
+        def mock_get_records(state):
+            raise freshdeskBadRequestError(
+                "Freshdesk 300 page limit reached"
+            )
+
+        self.stream.get_records = mock_get_records
+
+        with self.assertRaises(freshdeskBadRequestError):
+            self.stream.sync(self.state, self.transformer)
+
+        _, last_value = bookmark_writes[-1]
+        # 2023-01-01T00:00:00Z + 1s = 2023-01-01T00:00:01
+        self.assertIn("2023-01-01T00:00:01", last_value)

--- a/tests/unittests/test_client.py
+++ b/tests/unittests/test_client.py
@@ -1,0 +1,379 @@
+import unittest
+from unittest.mock import MagicMock, Mock, patch
+
+import requests
+
+from tap_freshdesk.client import Client, get_backoff_time, raise_for_error
+from tap_freshdesk.exceptions import (
+    freshdeskBackoffError,
+    freshdeskBadRequestError,
+    freshdeskError,
+    freshdeskInternalServerError,
+    freshdeskRateLimitError,
+    freshdeskUnauthorizedError,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_response(status_code, json_data=None, headers=None):
+    """Build a minimal mock requests.Response."""
+    resp = MagicMock(spec=requests.Response)
+    resp.status_code = status_code
+    resp.json.return_value = json_data or {}
+    resp.headers = headers or {}
+    return resp
+
+
+def _make_client():
+    return Client(
+        {
+            "api_key": "test_key",
+            "domain": "testdomain",
+            "start_date": "2023-01-01",
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# freshdeskRateLimitError
+# ---------------------------------------------------------------------------
+
+
+class TestFreshdeskRateLimitError(unittest.TestCase):
+    """Tests for the updated freshdeskRateLimitError.__init__."""
+
+    def test_retry_after_extracted_from_header(self):
+        """Retry-After header value is stored as a float."""
+        response = _make_response(429, headers={"Retry-After": "45"})
+        err = freshdeskRateLimitError("rate limited", response)
+        self.assertEqual(err.retry_after, 45.0)
+
+    def test_retry_after_float_in_header(self):
+        """Fractional Retry-After values are parsed correctly."""
+        response = _make_response(429, headers={"Retry-After": "1.5"})
+        err = freshdeskRateLimitError("rate limited", response)
+        self.assertEqual(err.retry_after, 1.5)
+
+    def test_retry_after_defaults_to_60_when_header_missing(self):
+        """Missing Retry-After header defaults to 60.0 (float) seconds."""
+        response = _make_response(429, headers={})
+        err = freshdeskRateLimitError("rate limited", response)
+        self.assertEqual(err.retry_after, 60.0)
+        self.assertIsInstance(err.retry_after, float)
+
+    def test_retry_after_defaults_to_60_on_invalid_value(self):
+        """Non-numeric Retry-After header defaults to 60 seconds."""
+        response = _make_response(
+            429, headers={"Retry-After": "not-a-number"}
+        )
+        err = freshdeskRateLimitError("rate limited", response)
+        self.assertEqual(err.retry_after, 60)
+
+    def test_retry_after_is_none_when_no_response(self):
+        """retry_after is None when no response object is given."""
+        err = freshdeskRateLimitError("rate limited")
+        self.assertIsNone(err.retry_after)
+
+    def test_message_includes_retry_after_seconds(self):
+        """Error message contains the Retry-After duration."""
+        response = _make_response(429, headers={"Retry-After": "30"})
+        err = freshdeskRateLimitError("Rate limited", response)
+        self.assertIn("Retry after 30.0 seconds", str(err))
+
+    def test_message_uses_default_text_when_no_custom_message(self):
+        """Default message is used when none is provided."""
+        response = _make_response(429, headers={"Retry-After": "30"})
+        err = freshdeskRateLimitError(response=response)
+        self.assertIn("FreshDesk Rate Limit Exceeded", str(err))
+
+    def test_message_has_no_retry_after_suffix_when_no_response(self):
+        """No 'Retry after' suffix when retry_after is None."""
+        err = freshdeskRateLimitError("Rate limited")
+        self.assertNotIn("Retry after", str(err))
+
+    def test_is_subclass_of_backoff_error(self):
+        """freshdeskRateLimitError must remain a freshdeskBackoffError."""
+        self.assertTrue(issubclass(freshdeskRateLimitError, freshdeskBackoffError))
+
+
+# ---------------------------------------------------------------------------
+# get_backoff_time
+# ---------------------------------------------------------------------------
+
+
+class TestGetBackoffTime(unittest.TestCase):
+    """Tests for the get_backoff_time() helper."""
+
+    def test_returns_retry_after_from_rate_limit_exception(self):
+        """Returns the retry_after value from a rate-limit exception."""
+        response = _make_response(429, headers={"Retry-After": "45"})
+        exception = freshdeskRateLimitError("rate limited", response)
+        result = get_backoff_time({"exception": exception})
+        self.assertEqual(result, 45.0)
+
+    def test_returns_default_when_retry_after_is_none(self):
+        """Returns 60 when the exception carries no retry_after."""
+        exception = freshdeskRateLimitError("rate limited")
+        # no response → retry_after is None
+        result = get_backoff_time({"exception": exception})
+        self.assertEqual(result, 60.0)
+
+    def test_returns_default_for_non_rate_limit_exception(self):
+        """Returns 60 when the exception is not a rate-limit error."""
+        result = get_backoff_time({"exception": Exception("generic")})
+        self.assertEqual(result, 60.0)
+
+    def test_handles_exception_passed_directly(self):
+        """Defensive branch: exception passed as the value instead of dict."""
+        exception = freshdeskRateLimitError("rate limited")
+        result = get_backoff_time(exception)
+        self.assertEqual(result, 60.0)
+
+    @patch("tap_freshdesk.client.LOGGER")
+    def test_warning_is_logged(self, mock_logger):
+        """A warning is always logged regardless of exception type."""
+        exception = freshdeskRateLimitError("rate limited")
+        get_backoff_time({"exception": exception})
+        mock_logger.warning.assert_called_once()
+
+    @patch("tap_freshdesk.client.LOGGER")
+    def test_logged_wait_time_matches_retry_after(self, mock_logger):
+        """The logged wait time matches the extracted retry_after."""
+        response = _make_response(429, headers={"Retry-After": "77"})
+        exception = freshdeskRateLimitError("rate limited", response)
+        get_backoff_time({"exception": exception})
+        logged_args = mock_logger.warning.call_args[0]
+        # second positional arg is the wait time
+        self.assertEqual(logged_args[1], 77.0)
+
+
+# ---------------------------------------------------------------------------
+# raise_for_error
+# ---------------------------------------------------------------------------
+
+
+class TestRaiseForError(unittest.TestCase):
+    """Tests for raise_for_error() HTTP status → exception mapping."""
+
+    def test_200_does_not_raise(self):
+        """A 200 response must not raise any exception."""
+        raise_for_error(_make_response(200))
+
+    def test_400_raises_bad_request_error(self):
+        with self.assertRaises(freshdeskBadRequestError):
+            raise_for_error(_make_response(400))
+
+    def test_401_raises_unauthorized_error(self):
+        with self.assertRaises(freshdeskUnauthorizedError):
+            raise_for_error(_make_response(401))
+
+    def test_429_raises_rate_limit_error(self):
+        with self.assertRaises(freshdeskRateLimitError):
+            raise_for_error(_make_response(429))
+
+    def test_500_raises_internal_server_error(self):
+        with self.assertRaises(freshdeskInternalServerError):
+            raise_for_error(_make_response(500))
+
+    def test_unknown_status_code_raises_freshdesk_error(self):
+        with self.assertRaises(freshdeskError):
+            raise_for_error(_make_response(418))
+
+    def test_error_message_taken_from_error_field(self):
+        """When JSON has an 'error' key, it appears in the exception message."""
+        response = _make_response(400, json_data={"error": "Bad input data"})
+        with self.assertRaises(freshdeskBadRequestError) as ctx:
+            raise_for_error(response)
+        self.assertIn("Bad input data", str(ctx.exception))
+
+    def test_error_message_taken_from_message_field(self):
+        """When JSON has a 'message' key, it appears in the exception message."""
+        response = _make_response(
+            400, json_data={"message": "Validation failed"}
+        )
+        with self.assertRaises(freshdeskBadRequestError) as ctx:
+            raise_for_error(response)
+        self.assertIn("Validation failed", str(ctx.exception))
+
+    def test_error_message_falls_back_to_mapping(self):
+        """When JSON has neither key, the mapping's default message is used."""
+        response = _make_response(400, json_data={})
+        with self.assertRaises(freshdeskBadRequestError) as ctx:
+            raise_for_error(response)
+        self.assertIn("400", str(ctx.exception))
+
+    def test_json_parse_failure_does_not_crash(self):
+        """If response.json() raises, raise_for_error still maps the error."""
+        response = _make_response(500)
+        response.json.side_effect = ValueError("not json")
+        with self.assertRaises(freshdeskInternalServerError):
+            raise_for_error(response)
+
+
+# ---------------------------------------------------------------------------
+# Client retry behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestClientRetryBehavior(unittest.TestCase):
+    """
+    Tests that verify the backoff/retry decorators on Client.__make_request.
+
+    Layout of decorators (outermost first):
+      @backoff.on_exception(expo,    NetworkErrors + freshdeskBackoffError)
+      @backoff.on_exception(runtime, freshdeskRateLimitError)
+      def __make_request(...)
+
+    Execution order when a request fails:
+      • freshdeskRateLimitError  → caught by inner (runtime) decorator first
+      • freshdeskBackoffError    → bypasses inner, caught by outer (expo) decorator
+      • Network errors           → bypasses inner, caught by outer (expo) decorator
+    """
+
+    def setUp(self):
+        self.client = _make_client()
+
+    # -- 429 rate-limit -------------------------------------------------------
+
+    @patch("time.sleep", return_value=None)
+    def test_rate_limit_error_is_retried(self, _mock_sleep):
+        """
+        A 429 response triggers the runtime-backoff retry.
+        Second call succeeds → result is returned.
+        """
+        self.client._session.request = Mock(
+            side_effect=[
+                _make_response(429, headers={"Retry-After": "0"}),
+                _make_response(200, json_data=[{"id": 1}]),
+            ]
+        )
+        result = self.client.get("http://test.com", {}, {})
+        self.assertEqual(self.client._session.request.call_count, 2)
+        self.assertEqual(result, [{"id": 1}])
+
+    @patch("time.sleep", return_value=None)
+    def test_rate_limit_retry_after_header_governs_sleep(self, mock_sleep):
+        """
+        The Retry-After value from the response governs the sleep duration
+        via get_backoff_time.
+        """
+        self.client._session.request = Mock(
+            side_effect=[
+                _make_response(429, headers={"Retry-After": "7"}),
+                _make_response(200, json_data=[{"id": 2}]),
+            ]
+        )
+        self.client.get("http://test.com", {}, {})
+        # time.sleep must have been called with the Retry-After value
+        sleep_calls = [call.args[0] for call in mock_sleep.call_args_list]
+        self.assertIn(7.0, sleep_calls)
+
+    # -- 5xx server errors (freshdeskBackoffError) ----------------------------
+
+    @patch("time.sleep", return_value=None)
+    def test_5xx_error_is_retried_with_expo_backoff(self, _mock_sleep):
+        """
+        Bug fix: freshdeskBackoffError (5xx) subclasses must be retried by
+        the exponential-backoff decorator.
+
+        Previously freshdeskBackoffError was removed from the outer decorator,
+        causing 5xx errors to propagate immediately without retry.
+        """
+        self.client._session.request = Mock(
+            side_effect=[
+                _make_response(500),
+                _make_response(200, json_data=[{"id": 3}]),
+            ]
+        )
+        result = self.client.get("http://test.com", {}, {})
+        self.assertEqual(self.client._session.request.call_count, 2)
+        self.assertEqual(result, [{"id": 3}])
+
+    @patch("time.sleep", return_value=None)
+    def test_502_bad_gateway_is_retried(self, _mock_sleep):
+        """502 Bad Gateway (a freshdeskBackoffError) must also be retried."""
+        self.client._session.request = Mock(
+            side_effect=[
+                _make_response(502),
+                _make_response(200, json_data=[{"id": 4}]),
+            ]
+        )
+        result = self.client.get("http://test.com", {}, {})
+        self.assertEqual(self.client._session.request.call_count, 2)
+        self.assertEqual(result, [{"id": 4}])
+
+    @patch("time.sleep", return_value=None)
+    def test_503_service_unavailable_is_retried(self, _mock_sleep):
+        """503 Service Unavailable must be retried."""
+        self.client._session.request = Mock(
+            side_effect=[
+                _make_response(503),
+                _make_response(200, json_data=[{"id": 5}]),
+            ]
+        )
+        result = self.client.get("http://test.com", {}, {})
+        self.assertEqual(self.client._session.request.call_count, 2)
+        self.assertEqual(result, [{"id": 5}])
+
+    # -- Network errors -------------------------------------------------------
+
+    @patch("time.sleep", return_value=None)
+    def test_timeout_is_retried(self, _mock_sleep):
+        """A Timeout exception must trigger exponential-backoff retry."""
+        from requests.exceptions import Timeout
+
+        self.client._session.request = Mock(
+            side_effect=[
+                Timeout(),
+                _make_response(200, json_data=[{"id": 6}]),
+            ]
+        )
+        result = self.client.get("http://test.com", {}, {})
+        self.assertEqual(self.client._session.request.call_count, 2)
+        self.assertEqual(result, [{"id": 6}])
+
+    @patch("time.sleep", return_value=None)
+    def test_connection_error_is_retried(self, _mock_sleep):
+        """A ConnectionError must trigger exponential-backoff retry."""
+        from requests.exceptions import ConnectionError as ReqConnError
+
+        self.client._session.request = Mock(
+            side_effect=[
+                ReqConnError(),
+                _make_response(200, json_data=[{"id": 7}]),
+            ]
+        )
+        result = self.client.get("http://test.com", {}, {})
+        self.assertEqual(self.client._session.request.call_count, 2)
+        self.assertEqual(result, [{"id": 7}])
+
+    # -- Non-retryable errors -------------------------------------------------
+
+    @patch("time.sleep", return_value=None)
+    def test_400_bad_request_is_not_retried(self, _mock_sleep):
+        """
+        freshdeskBadRequestError (400) does NOT extend freshdeskBackoffError
+        and must NOT be retried.
+        """
+        self.client._session.request = Mock(
+            return_value=_make_response(400)
+        )
+        with self.assertRaises(freshdeskBadRequestError):
+            self.client.get("http://test.com", {}, {})
+        # Only one attempt — no retry
+        self.assertEqual(self.client._session.request.call_count, 1)
+
+    @patch("time.sleep", return_value=None)
+    def test_rate_limit_exhausts_retries_and_reraises(self, _mock_sleep):
+        """
+        After exhausting max_tries (5) on 429s, the exception propagates.
+        """
+        self.client._session.request = Mock(
+            return_value=_make_response(429, headers={"Retry-After": "0"})
+        )
+        with self.assertRaises(freshdeskRateLimitError):
+            self.client.get("http://test.com", {}, {})
+        self.assertEqual(self.client._session.request.call_count, 5)


### PR DESCRIPTION
# Description of change
- Handled freshdesk's ticket stream limitation of max 300 pages.
- Tap now catches the 400 error and retries the sync with last record's bookmark state
- Also modified ratelimit handling to honor the Retry-After header.
- Added unittests.
JIRA: https://qlik-dev.atlassian.net/browse/SAC-31317

# Manual QA steps
 - [ ] Discovery running
 - [ ] Sync tested for specific stream
 - [ ] Unittests running
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
