### PR TITLE
Added access check in discovery (#66)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   * Added per-stream access checks during discovery; streams returning 401 Unauthorized or 403 Forbidden are excluded from the catalog [#66](https://github.com/singer-io/tap-freshdesk/pull/66)
   * Adds `parent-tap-stream-id` field to catalog [#64](https://github.com/singer-io/tap-freshdesk/pull/64)
   * singer-python upgrade to 6.8.0
+  * Handle the Freshdesk tickets endpoint's 400 and 429 errors [#69](https://github.com/singer-io/tap-freshdesk/pull/69)
 
 # 1.0.1
   * Bump requests to 2.33.0 for security updates [#66](https://github.com/singer-io/tap-freshdesk/pull/66)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.1.0
+  * Added per-stream access checks during discovery; streams returning 401 Unauthorized or 403 Forbidden are excluded from the catalog [#66](https://github.com/singer-io/tap-freshdesk/pull/66)
+
 ## 1.0.0
   * Complete refactoring of the tap [#60](https://github.com/singer-io/tap-freshdesk/pull/60)
   * Bump version of `requests` dependency to 2.32.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.0
+  * Adds `parent-tap-stream-id` field to catalog [#64](https://github.com/singer-io/tap-freshdesk/pull/64)
+  * singer-python upgrade to 6.8.0
+
 ## 1.0.0
   * Complete refactoring of the tap [#60](https://github.com/singer-io/tap-freshdesk/pull/60)
   * Bump version of `requests` dependency to 2.32.3

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     classifiers=["Programming Language :: Python :: 3 :: Only"],
     py_modules=["tap_freshdesk"],
     install_requires=[
-        "requests==2.34.0",
+        "requests==2.34.2",
         "singer-python==6.8.0",
         "backoff==2.2.1"],
     entry_points="""

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="tap-freshdesk",
-    version="1.0.0",
+    version="1.1.0",
     description="Singer.io tap for extracting data from freshdesk API",
     author="Stitch Dev",
     url="http://singer.io",

--- a/setup.py
+++ b/setup.py
@@ -2,15 +2,15 @@ from setuptools import setup, find_packages
 
 setup(
     name="tap-freshdesk",
-    version="1.0.0",
+    version="1.1.0",
     description="Singer.io tap for extracting data from freshdesk API",
     author="Stitch Dev",
     url="http://singer.io",
     classifiers=["Programming Language :: Python :: 3 :: Only"],
     py_modules=["tap_freshdesk"],
     install_requires=[
-        "requests==2.32.5",
-        "singer-python==6.1.0",
+        "requests==2.34.0",
+        "singer-python==6.8.0",
         "backoff==2.2.1"],
     entry_points="""
         [console_scripts]

--- a/tap_freshdesk/__init__.py
+++ b/tap_freshdesk/__init__.py
@@ -10,10 +10,10 @@ LOGGER = singer.get_logger()
 REQUIRED_CONFIG_KEYS = ["api_key", "domain", "start_date", "user_agent"]
 
 
-def do_discover():
+def do_discover(client):
 
     LOGGER.info("Starting discover")
-    catalog = discover()
+    catalog = discover(client)
     json.dump(catalog.to_dict(), sys.stdout, indent=2)
     LOGGER.info("Finished discover")
 
@@ -28,7 +28,7 @@ def main():
 
     with Client(parsed_args.config) as client:
         if parsed_args.discover:
-            do_discover()
+            do_discover(client)
         elif parsed_args.catalog:
             sync(
                 client=client,

--- a/tap_freshdesk/client.py
+++ b/tap_freshdesk/client.py
@@ -10,10 +10,32 @@ from tap_freshdesk.exceptions import (
     ERROR_CODE_EXCEPTION_MAPPING,
     freshdeskError,
     freshdeskBackoffError,
+    freshdeskRateLimitError,
 )
 
 LOGGER = get_logger()
 REQUEST_TIMEOUT = 300
+
+
+def get_backoff_time(exception_info) -> float:
+    """ Extracts the retry_after information from the rate-limit exception and returns it.
+    """
+
+    retry_after = 60.0  # Default backoff time in seconds
+
+    exception = exception_info.get("exception") if isinstance(exception_info, dict) else exception_info
+
+    if exception and isinstance(exception, freshdeskRateLimitError):
+        actual_retry_after = exception.retry_after
+        if actual_retry_after is not None:
+            retry_after = actual_retry_after
+
+    LOGGER.warning(
+        "Freshdesk rate limit encountered. Retrying after %s seconds.",
+        retry_after,
+    )
+
+    return retry_after
 
 
 def raise_for_error(response: requests.Response) -> None:
@@ -120,6 +142,16 @@ class Client:
         ),
         max_tries=5,
         factor=2,
+        # Do not re-retry rate-limit errors that already exhausted the inner
+        # runtime-backoff decorator; let them propagate immediately.
+        giveup=lambda e: isinstance(e, freshdeskRateLimitError),
+    )
+    @backoff.on_exception(
+        wait_gen=backoff.runtime,
+        exception=freshdeskRateLimitError,
+        value=get_backoff_time,
+        max_tries=5,
+        jitter=None
     )
     def __make_request(
         self, method: str, endpoint: str, **kwargs

--- a/tap_freshdesk/client.py
+++ b/tap_freshdesk/client.py
@@ -57,6 +57,7 @@ class Client:
     def __init__(self, config: Mapping[str, Any]) -> None:
         self.config = config
         self._session = session()
+        self._credentials_validated = False
         domain = config.get("domain")
         self.base_url = f"https://{domain}.freshdesk.com/api/v2"
 
@@ -73,7 +74,15 @@ class Client:
         self._session.close()
 
     def check_api_credentials(self) -> None:
-        pass
+        if self._credentials_validated:
+            return
+
+        self.get(
+            endpoint=f"{self.base_url}/agents/me",
+            params={},
+            headers={"Accept": "application/json"},
+        )
+        self._credentials_validated = True
 
     def get(self, endpoint: str, params: Dict, headers: Dict, path: str = None) -> Any:
         """Calls the make_request method with a prefixed method type `GET`"""

--- a/tap_freshdesk/discover.py
+++ b/tap_freshdesk/discover.py
@@ -2,16 +2,50 @@ import singer
 from singer import metadata
 from singer.catalog import Catalog, CatalogEntry, Schema
 from tap_freshdesk.schema import get_schemas
+from tap_freshdesk.streams import STREAMS
+from tap_freshdesk.exceptions import freshdeskUnauthorizedError, freshdeskForbiddenError, freshdeskNoAccessibleStreamsError
 
 LOGGER = singer.get_logger()
 
 
-def discover() -> Catalog:
-    """Run the discovery mode, prepare the catalog file and return the catalog."""
+def check_stream_access(client, stream_class) -> bool:
+    """
+    Probes a stream endpoint with page_size=1 to verify the credentials have access.
+    Child streams whose path contains '{}' require a parent ID and cannot be probed,
+    so they are assumed accessible.
+    Returns True if accessible, False on 401/403. Any other exception is re-raised.
+    """
+    if '{}' in stream_class.path:
+        return True
+
+    endpoint = f"{client.base_url}/{stream_class.path}"
+    try:
+        client.get(
+            endpoint=endpoint,
+            params={"per_page": 1, "page": 1},
+            headers={"Accept": "application/json"},
+        )
+        return True
+    except (freshdeskUnauthorizedError, freshdeskForbiddenError):
+        return False
+
+
+def discover(client) -> Catalog:
+    """Run the discovery mode, prepare the catalog file and return the catalog.
+    Probes each top-level stream endpoint to verify access; streams that return
+    401/403 are excluded from the catalog.
+    """
     schemas, field_metadata = get_schemas()
     catalog = Catalog([])
 
     for stream_name, schema_dict in schemas.items():
+        if not check_stream_access(client, STREAMS[stream_name]):
+            LOGGER.warning(
+                "Stream '%s' will be excluded from the catalog due to insufficient permissions.",
+                stream_name,
+            )
+            continue
+
         try:
             schema = Schema.from_dict(schema_dict)
             mdata = field_metadata[stream_name]
@@ -31,6 +65,11 @@ def discover() -> Catalog:
                 schema=schema,
                 metadata=mdata,
             )
+        )
+
+    if not catalog.streams:
+        raise freshdeskNoAccessibleStreamsError(
+            "The credentials do not have read access to any of the supported streams."
         )
 
     return catalog

--- a/tap_freshdesk/discover.py
+++ b/tap_freshdesk/discover.py
@@ -66,6 +66,7 @@ def discover(client) -> Catalog:
     Probes each stream endpoint to verify access; inaccessible streams are
     excluded from the returned catalog.
     """
+    client.check_api_credentials()
     schemas, field_metadata = get_schemas()
     _apply_access_checks(client, schemas, field_metadata)
     catalog = Catalog([])

--- a/tap_freshdesk/discover.py
+++ b/tap_freshdesk/discover.py
@@ -14,8 +14,9 @@ def check_stream_access(client, stream_class) -> bool:
     return stream_obj.check_access()
 
 
-def _prune_inaccessible_children(schemas: dict, field_metadata: dict) -> None:
+def _prune_inaccessible_children(schemas: dict, field_metadata: dict) -> list:
     """Remove child streams whose parent stream is unavailable."""
+    inaccessible_children = []
     removed_child = True
     while removed_child:
         removed_child = False
@@ -32,7 +33,9 @@ def _prune_inaccessible_children(schemas: dict, field_metadata: dict) -> None:
                 )
                 schemas.pop(stream_name, None)
                 field_metadata.pop(stream_name, None)
+                inaccessible_children.append(stream_name)
                 removed_child = True
+    return inaccessible_children
 
 
 def _apply_access_checks(client, schemas: dict, field_metadata: dict) -> None:
@@ -47,17 +50,21 @@ def _apply_access_checks(client, schemas: dict, field_metadata: dict) -> None:
         schemas.pop(stream_name, None)
         field_metadata.pop(stream_name, None)
 
-    _prune_inaccessible_children(schemas, field_metadata)
+    inaccessible_children = _prune_inaccessible_children(schemas, field_metadata)
 
     if not schemas:
         raise freshdeskNoAccessibleStreamsError(
             "The credentials do not have read access to any of the supported streams."
         )
 
-    if inaccessible_streams:
+    all_inaccessible = inaccessible_streams + [
+        stream_name for stream_name in inaccessible_children if stream_name not in inaccessible_streams
+    ]
+
+    if all_inaccessible:
         LOGGER.warning(
-            "No read access to stream(s): %s. Excluded from catalog.",
-            ", ".join(inaccessible_streams),
+            "Unauthorized streams excluded from catalog: %s",
+            ", ".join(all_inaccessible),
         )
 
 

--- a/tap_freshdesk/discover.py
+++ b/tap_freshdesk/discover.py
@@ -3,49 +3,74 @@ from singer import metadata
 from singer.catalog import Catalog, CatalogEntry, Schema
 from tap_freshdesk.schema import get_schemas
 from tap_freshdesk.streams import STREAMS
-from tap_freshdesk.exceptions import freshdeskUnauthorizedError, freshdeskForbiddenError, freshdeskNoAccessibleStreamsError
+from tap_freshdesk.exceptions import freshdeskNoAccessibleStreamsError
 
 LOGGER = singer.get_logger()
 
 
 def check_stream_access(client, stream_class) -> bool:
-    """
-    Probes a stream endpoint with page_size=1 to verify the credentials have access.
-    Child streams whose path contains '{}' require a parent ID and cannot be probed,
-    so they are assumed accessible.
-    Returns True if accessible, False on 401/403. Any other exception is re-raised.
-    """
-    if '{}' in stream_class.path:
-        return True
+    """Verify access for a stream by probing its endpoint."""
+    stream_obj = stream_class(client=client)
+    return stream_obj.check_access()
 
-    endpoint = f"{client.base_url}/{stream_class.path}"
-    try:
-        client.get(
-            endpoint=endpoint,
-            params={"per_page": 1, "page": 1},
-            headers={"Accept": "application/json"},
+
+def _prune_inaccessible_children(schemas: dict, field_metadata: dict) -> None:
+    """Remove child streams whose parent stream is unavailable."""
+    removed_child = True
+    while removed_child:
+        removed_child = False
+        for stream_name, stream_obj in list(STREAMS.items()):
+            if (
+                stream_name in schemas
+                and stream_obj.parent
+                and stream_obj.parent not in schemas
+            ):
+                LOGGER.warning(
+                    "Stream '%s' excluded from catalog because its parent stream '%s' is not accessible.",
+                    stream_name,
+                    stream_obj.parent,
+                )
+                schemas.pop(stream_name, None)
+                field_metadata.pop(stream_name, None)
+                removed_child = True
+
+
+def _apply_access_checks(client, schemas: dict, field_metadata: dict) -> None:
+    """Probe stream access and remove inaccessible streams in place."""
+    inaccessible_streams = [
+        stream_name
+        for stream_name in list(schemas.keys())
+        if not check_stream_access(client, STREAMS[stream_name])
+    ]
+
+    for stream_name in inaccessible_streams:
+        schemas.pop(stream_name, None)
+        field_metadata.pop(stream_name, None)
+
+    _prune_inaccessible_children(schemas, field_metadata)
+
+    if not schemas:
+        raise freshdeskNoAccessibleStreamsError(
+            "The credentials do not have read access to any of the supported streams."
         )
-        return True
-    except (freshdeskUnauthorizedError, freshdeskForbiddenError):
-        return False
+
+    if inaccessible_streams:
+        LOGGER.warning(
+            "No read access to stream(s): %s. Excluded from catalog.",
+            ", ".join(inaccessible_streams),
+        )
 
 
 def discover(client) -> Catalog:
     """Run the discovery mode, prepare the catalog file and return the catalog.
-    Probes each top-level stream endpoint to verify access; streams that return
-    401/403 are excluded from the catalog.
+    Probes each stream endpoint to verify access; inaccessible streams are
+    excluded from the returned catalog.
     """
     schemas, field_metadata = get_schemas()
+    _apply_access_checks(client, schemas, field_metadata)
     catalog = Catalog([])
 
     for stream_name, schema_dict in schemas.items():
-        if not check_stream_access(client, STREAMS[stream_name]):
-            LOGGER.warning(
-                "Stream '%s' will be excluded from the catalog due to insufficient permissions.",
-                stream_name,
-            )
-            continue
-
         try:
             schema = Schema.from_dict(schema_dict)
             mdata = field_metadata[stream_name]
@@ -65,11 +90,6 @@ def discover(client) -> Catalog:
                 schema=schema,
                 metadata=mdata,
             )
-        )
-
-    if not catalog.streams:
-        raise freshdeskNoAccessibleStreamsError(
-            "The credentials do not have read access to any of the supported streams."
         )
 
     return catalog

--- a/tap_freshdesk/exceptions.py
+++ b/tap_freshdesk/exceptions.py
@@ -58,7 +58,28 @@ class freshdeskUnprocessableEntityError(freshdeskBackoffError):
 class freshdeskRateLimitError(freshdeskBackoffError):
     """Class representing 429 status code."""
 
-    pass
+    def __init__(self, message=None, response=None):
+        """Initialize a Freshdesk rate-limit error and extract the Retry-After header from the response."""
+        self.response = response
+        self.message = message
+        self.retry_after = None
+
+        if response is not None:
+            headers = response.headers or {}
+
+            retry_after = headers.get("Retry-After")
+            # try to parse the retry_after value as a float, if it fails, default to 60 seconds
+            try:
+                self.retry_after = float(retry_after)
+            except (ValueError, TypeError):
+                self.retry_after = 60.0
+
+        base_message = self.message or "FreshDesk Rate Limit Exceeded"
+
+        if self.retry_after is not None:
+            base_message += f" - Retry after {self.retry_after} seconds"
+
+        super().__init__(base_message, response)
 
 
 class freshdeskInternalServerError(freshdeskBackoffError):

--- a/tap_freshdesk/exceptions.py
+++ b/tap_freshdesk/exceptions.py
@@ -7,6 +7,12 @@ class freshdeskError(Exception):
         self.response = response
 
 
+class freshdeskNoAccessibleStreamsError(freshdeskError):
+    """Raised during discovery when no stream endpoints are accessible with the provided credentials."""
+
+    pass
+
+
 class freshdeskBackoffError(freshdeskError):
     """Class representing backoff error handling."""
 

--- a/tap_freshdesk/schema.py
+++ b/tap_freshdesk/schema.py
@@ -56,6 +56,9 @@ def get_schemas() -> Tuple[Dict, Dict]:
             replication_method=getattr(stream_obj, "replication_method"),
         )
         mdata = metadata.to_map(mdata)
+        parent_stream_id = getattr(stream_obj, "parent", None)
+        if parent_stream_id and isinstance(parent_stream_id, str):
+            mdata = metadata.write(mdata, (), "parent-tap-stream-id", parent_stream_id)
 
         automatic_keys = getattr(stream_obj, "replication_keys") or []
         for field_name in schema["properties"].keys():

--- a/tap_freshdesk/streams/abstracts.py
+++ b/tap_freshdesk/streams/abstracts.py
@@ -555,6 +555,11 @@ class ParentBaseStream(IncrementalStream):
                         # Ref: https://developers.freshdesk.com/api/#list_all_tickets
                         # If number of restarts exceeds MAX_RESTARTS, the bookmark is advanced and
                         # The next sync will start from the advanced bookmark.
+                        # Scenario:
+                        # If the bookmark is set to a timestamp where there are more than 30,000 tickets, the sync will fail again.
+                        # We will keep hitting the same API with the same parameters.
+                        # To avoid this, we will advance the bookmark by 1 second and abort the sync. (A corner case)
+
                         LOGGER.warning(
                             "Freshdesk ticket limit reached for %s. "
                             "Restarting sync from bookmark %s "

--- a/tap_freshdesk/streams/abstracts.py
+++ b/tap_freshdesk/streams/abstracts.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from datetime import timedelta
 from typing import Any, Dict, Tuple, List
 import copy
 
@@ -19,6 +20,8 @@ from tap_freshdesk.exceptions import (
     freshdeskNotFoundError,
     freshdeskUnauthorizedError,
 )
+
+from tap_freshdesk.exceptions import freshdeskBadRequestError
 
 LOGGER = get_logger()
 
@@ -187,13 +190,18 @@ class BaseStream(ABC):
         params = {"per_page": 1, "page": 1}
         try:
             if self.parent:
-                from tap_freshdesk.streams import STREAMS
+                from tap_freshdesk.streams import STREAMS  # To fix circular import
+                parent_params = {"per_page": 1, "page": 1}
+
+                if self.parent == "tickets":
+                    updated_since = self.get_bookmark({}, self.tap_stream_id)
+                    parent_params["updated_since"] = updated_since
 
                 parent_stream = STREAMS[self.parent](client=self.client)
                 parent_endpoint = f"{self.client.base_url}/{parent_stream.path}"
                 parent_records = self.client.get(
                     endpoint=parent_endpoint,
-                    params=params,
+                    params=parent_params,
                     headers=self.headers,
                 )
 
@@ -301,9 +309,9 @@ class IncrementalStream(BaseStream):
             yield from raw_records
 
             if len(raw_records) == self.page_size:
-                LOGGER.info("Fetching Page %s", page_count)
                 page_count += 1
                 self.params["page"] = page_count
+                LOGGER.info("Fetching Page %s", page_count)
             else:
                 break
 
@@ -418,11 +426,11 @@ class ParentBaseStream(IncrementalStream):
         return state
 
     def sync(
-    self,
-    state: Dict,
-    transformer: Transformer,
-    parent_obj: Dict = None,
-) -> Dict:
+        self,
+        state: Dict,
+        transformer: Transformer,
+        parent_obj: Dict = None,
+    ) -> Dict:
         """Implementation for `type: Incremental` stream."""
         self.url_endpoint = self.get_url_endpoint(parent_obj)
 
@@ -435,6 +443,11 @@ class ParentBaseStream(IncrementalStream):
             }
         )
 
+        MAX_RESTARTS = 10  # Max number of retries if Freshdesk's 300 pages/30,000 ticket limit is hit
+        # Tracks IDs processed for the current updated_at timestamp
+        self.ids_cache = set()
+        self.current_timestamp_window = None
+
         with metrics.record_counter(self.tap_stream_id) as counter:
             filter_values = [{}, {"filter": "spam"}, {"filter": "deleted"}]
             for value in filter_values:
@@ -444,43 +457,137 @@ class ParentBaseStream(IncrementalStream):
                     ticket_key = (
                         self.tap_stream_id
                     )  # Default key when value is None or empty
-                current_max_bookmark_date = bookmark_date = updated_since = (
-                    self.get_bookmark(state, ticket_key)
-                )
-                self.params.update({"updated_since": updated_since})
-                self.params.update(**value)
-                for record in self.get_records(state):
-                    if "custom_fields" in record:
-                        record["custom_fields"] = self.modify_object_custom_fields(
-                            record["custom_fields"], force_to_string=True
-                        )
-                    transformed_record = transformer.transform(
-                        record, self.schema, self.metadata
+
+                # Added a workflow with try/except to handle Freshdesk's ticket endpoint limitation.
+                # The Tickets endpoint returns a maximum of 300 pages (30,000 tickets).
+                # If a request would exceed this limit, the API returns a 400 error.
+                # Ref: https://developers.freshdesk.com/api/#list_all_tickets
+                restart_count = 0  # Counter check for max 400 error retries
+                sync_completed = False  # Flag to handle the while loop
+
+                while not sync_completed:  # If the sync was interrupted, the core workflow will be resumed with updated state
+
+                    current_max_bookmark_date = bookmark_date = updated_since = (
+                        self.get_bookmark(state, ticket_key)
                     )
+                    self.params.update({"updated_since": updated_since})
+                    self.params.update(**value)
 
-                    record_timestamp = transformed_record[self.replication_keys[0]]
-                    if record_timestamp >= bookmark_date:
-                        # Only write parent records if parent is selected
-                        if self.is_selected():
-                            write_record(self.tap_stream_id, transformed_record)
-                            counter.increment()
+                    try:
+                        for record in self.get_records(state):
 
-                        # Sync only selected child streams
-                        for child in self.child_to_sync:
-                            if self.is_child_selected(child):
-                                child.sync(
-                                    state=state,
-                                    transformer=transformer,
-                                    parent_obj=record
+                            if "custom_fields" in record:
+                                record["custom_fields"] = self.modify_object_custom_fields(
+                                    record["custom_fields"], force_to_string=True
+                                )
+                            transformed_record = transformer.transform(
+                                record, self.schema, self.metadata
+                            )
+
+                            record_timestamp = transformed_record[self.replication_keys[0]]
+
+                            # Timestamp window handling
+                            # Example:
+                            # 10:00 -> cache {1,2,3}
+                            # 10:01 -> clear cache
+                            # 10:02 -> clear cache
+                            if self.current_timestamp_window != record_timestamp:
+                                LOGGER.info(
+                                    "Moving timestamp window from %s to %s. "
+                                    "Clearing ID cache.",
+                                    self.current_timestamp_window,
+                                    record_timestamp,
                                 )
 
-                        current_max_bookmark_date = max(
-                            current_max_bookmark_date, record_timestamp
+                                self.current_timestamp_window = record_timestamp
+                                self.ids_cache.clear()
+
+                            # Check if the record has already been synced using the ids_cache to avoid duplicates
+                            cache_key = ticket_key + "_" + str(record["id"])
+                            if cache_key in self.ids_cache:
+                                LOGGER.info(
+                                    "Skipping already processed ticket id=%s "
+                                    "for timestamp=%s",
+                                    cache_key,
+                                    record_timestamp,
+                                )
+                                continue
+
+                            if record_timestamp >= bookmark_date:
+                                # Only write parent records if parent is selected
+                                if self.is_selected():
+                                    write_record(self.tap_stream_id, transformed_record)
+                                    counter.increment()
+
+                                # Sync only selected child streams
+                                for child in self.child_to_sync:
+                                    if self.is_child_selected(child):
+                                        child.sync(
+                                            state=state,
+                                            transformer=transformer,
+                                            parent_obj=record
+                                        )
+
+                                # Add to cache ONLY after successful processing
+                                self.ids_cache.add(cache_key)
+
+                                current_max_bookmark_date = max(
+                                    current_max_bookmark_date, record_timestamp
+                                )
+
+                        # Sync completed successfully.
+                        state = self.write_bookmark(
+                            state,
+                            ticket_key,
+                            value=current_max_bookmark_date,
                         )
 
-                state = self.write_bookmark(
-                    state, ticket_key, value=current_max_bookmark_date
-                )
+                        sync_completed = True
+
+                    except freshdeskBadRequestError:
+                        restart_count += 1
+                        # handle a freshdesk bad-request error. Then rerun the sync with the state set to current_max_bookmark_date.
+                        # Ref: https://developers.freshdesk.com/api/#list_all_tickets
+                        LOGGER.warning(
+                            "Freshdesk ticket limit reached for %s. "
+                            "Restarting sync from bookmark %s "
+                            "(attempt %s/%s)",
+                            ticket_key,
+                            current_max_bookmark_date,
+                            restart_count,
+                            MAX_RESTARTS,
+                        )
+                        if restart_count >= MAX_RESTARTS:
+                            advanced_bookmark = strftime(
+                                strptime_to_utc(current_max_bookmark_date)
+                                + timedelta(seconds=1)
+                            )
+
+                            LOGGER.error(
+                                "Max restart attempts reached for %s. "
+                                "Advancing bookmark from %s to %s and aborting sync.",
+                                ticket_key,
+                                current_max_bookmark_date,
+                                advanced_bookmark,
+                            )
+
+                            state = self.write_bookmark(
+                                state,
+                                ticket_key,
+                                value=advanced_bookmark,
+                            )
+
+                            raise
+
+                        # Persist progress before restarting
+                        state = self.write_bookmark(
+                            state,
+                            ticket_key,
+                            value=current_max_bookmark_date,
+                        )
+
+                        # Loop restarts automatically
+
             return counter.value
 
 

--- a/tap_freshdesk/streams/abstracts.py
+++ b/tap_freshdesk/streams/abstracts.py
@@ -443,8 +443,9 @@ class ParentBaseStream(IncrementalStream):
             }
         )
 
-        # Max number of retries if Freshdesk's 300 pages/30,000 ticket limit is hit
-        # This will make sure that we don't get stuck in an infinite loop if the limit is hit repeatedly
+        # Maximum number of retries when the Freshdesk Tickets API limit
+        # (300 pages / 30,000 tickets) is reached.
+        # This prevents the sync from entering an infinite retry loop if the limit is encountered repeatedly.
         MAX_RESTARTS = 10
 
         # Tracks IDs processed for the current bookmark window to avoid duplicates.
@@ -461,10 +462,11 @@ class ParentBaseStream(IncrementalStream):
                         self.tap_stream_id
                     )  # Default key when value is None or empty
 
-                # Added a workflow with try/except to handle Freshdesk's ticket endpoint limitation.
-                # The Tickets endpoint returns a maximum of 300 pages (30,000 tickets).
-                # If a request would exceed this limit, the API returns a 400 error.
-                # Ref: https://developers.freshdesk.com/api/#list_all_tickets
+                # Added a try/except workflow to gracefully handle the Freshdesk Tickets API limit.
+                # The Tickets endpoint returns a maximum of 300 pages (30,000 tickets) in a single request.
+                # Requests exceeding this limit result in a 400 response, so we catch the error
+                # and handle it to allow the sync to continue from the appropriate bookmark.
+                # Reference: https://developers.freshdesk.com/api/#list_all_tickets
                 restart_count = 0  # Counter check for max 400 error retries
                 sync_completed = False  # Flag to handle the while loop
 
@@ -489,9 +491,9 @@ class ParentBaseStream(IncrementalStream):
 
                             record_timestamp = transformed_record[self.replication_keys[0]]
 
-                            # Timestamp window handling.
-                            # If the timestamp changes, then we reset our cache of IDs to avoid duplicates.
-                            # This ensures that each record is processed only once within the same timestamp window.
+                            # Handle records grouped by timestamp.
+                            # Reset the cached IDs whenever the timestamp changes to ensure
+                            # each record is processed only once within a given timestamp.
                             # Example:
                             # 10:00 -> cache {1,2,3}
                             # 10:01 -> clear cache
@@ -551,14 +553,19 @@ class ParentBaseStream(IncrementalStream):
 
                     except freshdeskBadRequestError:
                         restart_count += 1
-                        # Handle a freshdesk bad-request error. Then rerun the sync with the state set to current_max_bookmark_date.
+                        # Handle a Freshdesk bad request error by restarting the sync with the
+                        # bookmark reset to current_max_bookmark_date.
                         # Ref: https://developers.freshdesk.com/api/#list_all_tickets
-                        # If number of restarts exceeds MAX_RESTARTS, the bookmark is advanced and
-                        # The next sync will start from the advanced bookmark.
-                        # Scenario:
-                        # If the bookmark is set to a timestamp where there are more than 30,000 tickets, the sync will fail again.
-                        # We will keep hitting the same API with the same parameters.
-                        # To avoid this, we will advance the bookmark by 1 second and abort the sync. (A corner case)
+                        #
+                        # If the number of restart attempts exceeds MAX_RESTARTS, advance the
+                        # bookmark and terminate the current sync. The next sync will resume from
+                        # the updated bookmark.
+                        #
+                        # Corner case:
+                        # If the bookmark points to a timestamp with more than 30,000 tickets,
+                        # every retry will fail because the API request parameters remain
+                        # unchanged. To prevent an endless retry loop, advance the bookmark by
+                        # one second and abort the current sync.
 
                         LOGGER.warning(
                             "Freshdesk ticket limit reached for %s. "

--- a/tap_freshdesk/streams/abstracts.py
+++ b/tap_freshdesk/streams/abstracts.py
@@ -443,10 +443,13 @@ class ParentBaseStream(IncrementalStream):
             }
         )
 
-        MAX_RESTARTS = 10  # Max number of retries if Freshdesk's 300 pages/30,000 ticket limit is hit
-        # Tracks IDs processed for the current updated_at timestamp
-        self.ids_cache = set()
-        self.current_timestamp_window = None
+        # Max number of retries if Freshdesk's 300 pages/30,000 ticket limit is hit
+        # This will make sure that we don't get stuck in an infinite loop if the limit is hit repeatedly
+        MAX_RESTARTS = 10
+
+        # Tracks IDs processed for the current bookmark window to avoid duplicates.
+        ids_cache = set()
+        current_timestamp_window = None
 
         with metrics.record_counter(self.tap_stream_id) as counter:
             filter_values = [{}, {"filter": "spam"}, {"filter": "deleted"}]
@@ -486,25 +489,27 @@ class ParentBaseStream(IncrementalStream):
 
                             record_timestamp = transformed_record[self.replication_keys[0]]
 
-                            # Timestamp window handling
+                            # Timestamp window handling.
+                            # If the timestamp changes, then we reset our cache of IDs to avoid duplicates.
+                            # This ensures that each record is processed only once within the same timestamp window.
                             # Example:
                             # 10:00 -> cache {1,2,3}
                             # 10:01 -> clear cache
                             # 10:02 -> clear cache
-                            if self.current_timestamp_window != record_timestamp:
+                            if current_timestamp_window != record_timestamp:
                                 LOGGER.info(
                                     "Moving timestamp window from %s to %s. "
                                     "Clearing ID cache.",
-                                    self.current_timestamp_window,
+                                    current_timestamp_window,
                                     record_timestamp,
                                 )
 
-                                self.current_timestamp_window = record_timestamp
-                                self.ids_cache.clear()
+                                current_timestamp_window = record_timestamp
+                                ids_cache.clear()
 
                             # Check if the record has already been synced using the ids_cache to avoid duplicates
                             cache_key = ticket_key + "_" + str(record["id"])
-                            if cache_key in self.ids_cache:
+                            if cache_key in ids_cache:
                                 LOGGER.info(
                                     "Skipping already processed ticket id=%s "
                                     "for timestamp=%s",
@@ -529,7 +534,7 @@ class ParentBaseStream(IncrementalStream):
                                         )
 
                                 # Add to cache ONLY after successful processing
-                                self.ids_cache.add(cache_key)
+                                ids_cache.add(cache_key)
 
                                 current_max_bookmark_date = max(
                                     current_max_bookmark_date, record_timestamp
@@ -546,8 +551,10 @@ class ParentBaseStream(IncrementalStream):
 
                     except freshdeskBadRequestError:
                         restart_count += 1
-                        # handle a freshdesk bad-request error. Then rerun the sync with the state set to current_max_bookmark_date.
+                        # Handle a freshdesk bad-request error. Then rerun the sync with the state set to current_max_bookmark_date.
                         # Ref: https://developers.freshdesk.com/api/#list_all_tickets
+                        # If number of restarts exceeds MAX_RESTARTS, the bookmark is advanced and
+                        # The next sync will start from the advanced bookmark.
                         LOGGER.warning(
                             "Freshdesk ticket limit reached for %s. "
                             "Restarting sync from bookmark %s "
@@ -557,6 +564,8 @@ class ParentBaseStream(IncrementalStream):
                             restart_count,
                             MAX_RESTARTS,
                         )
+
+                        # If the max restart attempts are reached, advance the bookmark and abort the sync.
                         if restart_count >= MAX_RESTARTS:
                             advanced_bookmark = strftime(
                                 strptime_to_utc(current_max_bookmark_date)

--- a/tap_freshdesk/streams/abstracts.py
+++ b/tap_freshdesk/streams/abstracts.py
@@ -14,6 +14,12 @@ from singer import (
 )
 from singer.utils import strftime, strptime_to_utc
 
+from tap_freshdesk.exceptions import (
+    freshdeskForbiddenError,
+    freshdeskNotFoundError,
+    freshdeskUnauthorizedError,
+)
+
 LOGGER = get_logger()
 
 
@@ -39,8 +45,8 @@ class BaseStream(ABC):
     def __init__(self, client=None, catalog=None) -> None:
         self.client = client
         self.catalog = catalog
-        self.schema = catalog.schema.to_dict()
-        self.metadata = metadata.to_map(catalog.metadata)
+        self.schema = catalog.schema.to_dict() if catalog else {}
+        self.metadata = metadata.to_map(catalog.metadata) if catalog else {}
         self.child_to_sync = []
         self.params = {}
 
@@ -174,6 +180,55 @@ class BaseStream(ABC):
     def get_url_endpoint(self, parent_obj: Dict = None) -> str:
         """Get the URL endpoint for the stream"""
         return self.url_endpoint
+
+    def check_access(self) -> bool:
+        """Verify that the API credentials have read access to this stream."""
+        endpoint = f"{self.client.base_url}/{self.path}"
+        params = {"per_page": 1, "page": 1}
+        try:
+            if self.parent:
+                from tap_freshdesk.streams import STREAMS
+
+                parent_stream = STREAMS[self.parent](client=self.client)
+                parent_endpoint = f"{self.client.base_url}/{parent_stream.path}"
+                parent_records = self.client.get(
+                    endpoint=parent_endpoint,
+                    params=params,
+                    headers=self.headers,
+                )
+
+                if not parent_records:
+                    LOGGER.warning(
+                        "Stream '%s' could not be probed because parent stream '%s' has no records.",
+                        self.tap_stream_id,
+                        self.parent,
+                    )
+                    return True
+
+                endpoint = f"{self.client.base_url}/{self.path.format(parent_records[0]['id'])}"
+
+            self.client.get(
+                endpoint=endpoint,
+                params=params,
+                headers=self.headers,
+            )
+            return True
+        except (freshdeskUnauthorizedError, freshdeskForbiddenError) as err:
+            LOGGER.warning(
+                "Permission Error: Stream '%s' - %s",
+                self.tap_stream_id,
+                err,
+            )
+            return False
+        except freshdeskNotFoundError as err:
+            if "Account not found for the provided domain" in str(err):
+                LOGGER.warning(
+                    "Permission Error: Stream '%s' - %s",
+                    self.tap_stream_id,
+                    err,
+                )
+                return False
+            raise
 
 
 class IncrementalStream(BaseStream):

--- a/tap_freshdesk/utils.py
+++ b/tap_freshdesk/utils.py
@@ -6,11 +6,7 @@ import json
 import os
 import time
 
-import singer
-
 DATETIME_FMT = "%Y-%m-%dT%H:%M:%SZ"
-
-LOGGER = singer.get_logger()
 
 
 def strptime(dt):

--- a/tap_freshdesk/utils.py
+++ b/tap_freshdesk/utils.py
@@ -6,7 +6,11 @@ import json
 import os
 import time
 
+import singer
+
 DATETIME_FMT = "%Y-%m-%dT%H:%M:%SZ"
+
+LOGGER = singer.get_logger()
 
 
 def strptime(dt):

--- a/tests/base.py
+++ b/tests/base.py
@@ -50,7 +50,8 @@ class FreshdeskBaseTest(BaseCase):
                 cls.REPLICATION_METHOD: cls.INCREMENTAL,
                 cls.REPLICATION_KEYS: {"updated_at"},
                 cls.EXPECTED_PAGE_SIZE: 100,
-                cls.API_LIMIT: 100
+                cls.API_LIMIT: 100,
+                cls.PARENT_TAP_STREAM_ID: "tickets"
             },
             "groups": {
                 cls.PRIMARY_KEYS: {"id"},
@@ -69,7 +70,8 @@ class FreshdeskBaseTest(BaseCase):
                 cls.REPLICATION_METHOD: cls.INCREMENTAL,
                 cls.REPLICATION_KEYS: {"updated_at"},
                 cls.EXPECTED_PAGE_SIZE: 100,
-                cls.API_LIMIT: 100
+                cls.API_LIMIT: 100,
+                cls.PARENT_TAP_STREAM_ID: "tickets"
             },
             "tickets": {
                 cls.PRIMARY_KEYS: {"id"},
@@ -83,7 +85,8 @@ class FreshdeskBaseTest(BaseCase):
                 cls.REPLICATION_METHOD: cls.INCREMENTAL,
                 cls.REPLICATION_KEYS: {"updated_at"},
                 cls.EXPECTED_PAGE_SIZE: 100,
-                cls.API_LIMIT: 100
+                cls.API_LIMIT: 100,
+                cls.PARENT_TAP_STREAM_ID: "tickets"
             },
         }
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -10,6 +10,7 @@ class FreshdeskBaseTest(BaseCase):
     """
 
     start_date = "2017-01-01T00:00:00Z"
+    PARENT_TAP_STREAM_ID = "parent-tap-stream-id"
 
     @staticmethod
     def tap_name():

--- a/tests/base.py
+++ b/tests/base.py
@@ -11,6 +11,7 @@ class FreshdeskBaseTest(BaseCase):
 
     start_date = "2017-01-01T00:00:00Z"
     PARENT_TAP_STREAM_ID = "parent-tap-stream-id"
+    IS_FORBIDDEN_STREAM = "is-forbidden-stream"
 
     @staticmethod
     def tap_name():
@@ -72,7 +73,8 @@ class FreshdeskBaseTest(BaseCase):
                 cls.REPLICATION_KEYS: {"updated_at"},
                 cls.EXPECTED_PAGE_SIZE: 100,
                 cls.API_LIMIT: 100,
-                cls.PARENT_TAP_STREAM_ID: "tickets"
+                cls.PARENT_TAP_STREAM_ID: "tickets",
+                cls.IS_FORBIDDEN_STREAM: True
             },
             "tickets": {
                 cls.PRIMARY_KEYS: {"id"},
@@ -87,8 +89,18 @@ class FreshdeskBaseTest(BaseCase):
                 cls.REPLICATION_KEYS: {"updated_at"},
                 cls.EXPECTED_PAGE_SIZE: 100,
                 cls.API_LIMIT: 100,
-                cls.PARENT_TAP_STREAM_ID: "tickets"
+                cls.PARENT_TAP_STREAM_ID: "tickets",
+                cls.IS_FORBIDDEN_STREAM: True
             },
+        }
+
+    @classmethod
+    def expected_stream_names(cls):
+        """A set of expected stream names"""
+        return {
+            stream_name
+            for stream_name, metadata in cls.expected_metadata().items()
+            if not metadata.get(cls.IS_FORBIDDEN_STREAM, False)
         }
 
     @staticmethod

--- a/tests/unittests/test_abstracts.py
+++ b/tests/unittests/test_abstracts.py
@@ -1,6 +1,9 @@
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, Mock
 from tap_freshdesk.streams.abstracts import ParentBaseStream, ChildBaseStream, IncrementalStream
+
+from tap_freshdesk.streams import Tickets
+from tap_freshdesk.exceptions import freshdeskBadRequestError
 
 
 class ConcreteParentBaseStream(ParentBaseStream):
@@ -484,3 +487,602 @@ class TestIncrementalStream(unittest.TestCase):
         result = self.stream.get_bookmark(state, "test_stream")
         
         self.assertEqual(result, "2023-01-01")
+
+
+class TestTicketsSync(unittest.TestCase):
+
+    @patch("tap_freshdesk.streams.abstracts.metadata.to_map")
+    def setUp(self, mock_to_map):
+        mock_catalog = MagicMock()
+        mock_catalog.schema.to_dict.return_value = {"key": "value"}
+        mock_catalog.metadata = "mock_metadata"
+        mock_to_map.return_value = {"metadata_key": "metadata_value"}
+
+        mock_client = MagicMock()
+        mock_client.config = {"start_date": "2023-01-01"}
+        self.stream = Tickets(client=mock_client, catalog=mock_catalog)
+
+        self.stream.is_selected = Mock(return_value=True)
+        self.stream.is_child_selected = Mock(return_value=True)
+
+        self.stream.child_to_sync = []
+
+        self.transformer = Mock()
+        self.transformer.transform.side_effect = (
+            lambda record, *args: record
+        )
+
+        self.state = {}
+
+    @patch("tap_freshdesk.streams.abstracts.write_record")
+    def test_sync_happy_path(self, mock_write_record):
+        """
+        Verify all records are written and bookmark is updated.
+        """
+
+        self.stream.get_bookmark = Mock(
+            return_value="2024-01-01T00:00:00Z"
+        )
+
+        self.stream.write_bookmark = Mock(
+            side_effect=lambda state, key, value: state
+        )
+
+        self.stream.get_records = Mock(
+            side_effect=lambda state: iter(
+                [
+                    {
+                        "id": 1,
+                        "updated_at": "2024-01-01T01:00:00Z",
+                    },
+                    {
+                        "id": 2,
+                        "updated_at": "2024-01-01T02:00:00Z",
+                    },
+                ]
+            )
+        )
+
+        self.stream.sync(
+            self.state,
+            self.transformer,
+        )
+
+        # Call count for 2 records, for all 3 filter types (all, spam, deleted)
+        self.assertEqual(mock_write_record.call_count, 2*3)
+
+        self.stream.write_bookmark.assert_called()
+
+    @patch("tap_freshdesk.streams.abstracts.write_record")
+    def test_restart_after_400(self, mock_write_record):
+        """
+        Verify sync restarts after Freshdesk 300-page error.
+        """
+
+        self.stream.get_bookmark = Mock(
+            return_value="2024-01-01T00:00:00Z"
+        )
+
+        self.stream.write_bookmark = Mock(
+            side_effect=lambda state, key, value: state
+        )
+
+        call_count = 0
+
+        def mock_get_records(state):
+            nonlocal call_count
+
+            call_count += 1
+
+            if call_count == 1:
+                yield {
+                    "id": 1,
+                    "updated_at": "2024-01-01T01:00:00Z",
+                }
+
+                raise freshdeskBadRequestError(
+                    "Freshdesk 300 page limit reached"
+                )
+
+            yield {
+                "id": 1,
+                "updated_at": "2024-01-01T01:00:00Z",
+            }
+
+            yield {
+                "id": 2,
+                "updated_at": "2024-01-01T01:00:00Z",
+            }
+
+        self.stream.get_records = mock_get_records
+
+        self.stream.sync(
+            self.state,
+            self.transformer,
+        )
+        #
+        # ticket 1 emitted once
+        # ticket 2 emitted once
+        # This is done 3 times for all filter types 
+        self.assertEqual(
+            mock_write_record.call_count,
+            2*3,
+        )
+
+        self.assertEqual(
+            call_count,
+            4,
+        )
+
+    @patch("tap_freshdesk.streams.abstracts.write_record")
+    def test_same_ticket_processed_again_after_timestamp_window_change(
+        self,
+        mock_write_record,
+    ):
+        """
+        Scenario:
+
+        pk1  updated_at=1
+        pk2  updated_at=1
+        pk3  updated_at=1
+
+        cache = {1,2,3}
+
+        --------------------------------
+
+        pk4  updated_at=2
+        pk5  updated_at=2
+        pk6  updated_at=2
+
+        cache cleared
+
+        cache = {4,5,6}
+
+        --------------------------------
+
+        pk1  updated_at=3
+
+        cache cleared
+
+        pk1 should be written again because
+        deduplication is only scoped to the
+        current timestamp window.
+        """
+
+        self.stream.get_bookmark = Mock(
+            return_value="2024-01-01T00:00:00Z"
+        )
+
+        self.stream.write_bookmark = Mock(
+            side_effect=lambda state, key, value: state
+        )
+
+        records = [
+            {
+                "id": 1,
+                "updated_at": "2024-01-01T01:00:00Z",
+            },
+            {
+                "id": 2,
+                "updated_at": "2024-01-01T01:00:00Z",
+            },
+            {
+                "id": 3,
+                "updated_at": "2024-01-01T01:00:00Z",
+            },
+            {
+                "id": 4,
+                "updated_at": "2024-01-01T02:00:00Z",
+            },
+            {
+                "id": 5,
+                "updated_at": "2024-01-01T02:00:00Z",
+            },
+            {
+                "id": 6,
+                "updated_at": "2024-01-01T02:00:00Z",
+            },
+            {
+                "id": 1,
+                "updated_at": "2024-01-01T03:00:00Z",
+            },
+        ]
+
+        # Note: The get_records method is mocked to return an iterator over the records list.
+        # Hence the iterator will be exhausted after the first filter loop
+        # and the subsequent filter loops will not yield any records.
+        self.stream.get_records = Mock(
+            return_value=iter(records)
+        )
+
+        self.stream.sync(
+            self.state,
+            self.transformer,
+        )
+
+        #
+        # Expected writes:
+        #
+        # id=1 @ 01:00
+        # id=2 @ 01:00
+        # id=3 @ 01:00
+        # id=4 @ 02:00
+        # id=5 @ 02:00
+        # id=6 @ 02:00
+        # id=1 @ 03:00
+        #
+        self.assertEqual(
+            mock_write_record.call_count,
+            7,
+        )
+
+        written_ids = [
+            call.args[1]["id"]
+            for call in mock_write_record.call_args_list
+        ]
+
+        self.assertEqual(
+            written_ids,
+            [1, 2, 3, 4, 5, 6, 1]
+        )
+
+    @patch("tap_freshdesk.streams.abstracts.write_record")
+    def test_duplicate_same_timestamp_skipped(
+        self,
+        mock_write_record,
+    ):
+        """
+        Verify duplicate ticket IDs in same timestamp
+        window are skipped.
+        """
+
+        self.stream.get_bookmark = Mock(
+            return_value="2024-01-01T00:00:00Z"
+        )
+
+        self.stream.write_bookmark = Mock(
+            side_effect=lambda state, key, value: state
+        )
+
+        self.stream.get_records = Mock(
+            return_value=iter(
+                [
+                    {
+                        "id": 1,
+                        "updated_at": "2024-01-01T01:00:00Z",
+                    },
+                    {
+                        "id": 1,
+                        "updated_at": "2024-01-01T01:00:00Z",
+                    },
+                ]
+            )
+        )
+
+        self.stream.sync(
+            self.state,
+            self.transformer,
+        )
+
+        self.assertEqual(
+            mock_write_record.call_count,
+            1,
+        )
+
+    @patch("tap_freshdesk.streams.abstracts.write_record")
+    def test_same_ticket_new_timestamp_processed(
+        self,
+        mock_write_record,
+    ):
+        """
+        Verify same ticket ID is emitted again
+        when updated_at changes.
+        """
+
+        self.stream.get_bookmark = Mock(
+            return_value="2024-01-01T00:00:00Z"
+        )
+
+        self.stream.write_bookmark = Mock(
+            side_effect=lambda state, key, value: state
+        )
+
+        self.stream.get_records = Mock(
+            return_value=iter(
+                [
+                    {
+                        "id": 1,
+                        "updated_at": "2024-01-01T01:00:00Z",
+                    },
+                    {
+                        "id": 1,
+                        "updated_at": "2024-01-01T02:00:00Z",
+                    },
+                ]
+            )
+        )
+
+        self.stream.sync(
+            self.state,
+            self.transformer,
+        )
+
+        self.assertEqual(
+            mock_write_record.call_count,
+            2,  # Since the iterator will be ehausted after normal filters,
+                # the spam and deleted filters will not get any records.
+        )
+
+    @patch("tap_freshdesk.streams.abstracts.write_record")
+    def test_bookmark_written_before_restart(
+        self,
+        mock_write_record,
+    ):
+        """
+        Verify bookmark is persisted before retry.
+        """
+
+        bookmark_values = []
+
+        def mock_write_bookmark(
+            state,
+            key,
+            value,
+        ):
+            bookmark_values.append(value)
+            return state
+
+        self.stream.write_bookmark = Mock(
+            side_effect=mock_write_bookmark
+        )
+
+        self.stream.get_bookmark = Mock(
+            return_value="2024-01-01T00:00:00Z"
+        )
+
+        call_count = 0
+
+        def mock_get_records(state):
+            nonlocal call_count
+
+            call_count += 1
+
+            yield {
+                "id": 1,
+                "updated_at": "2024-01-01T05:00:00Z",
+            }
+
+            if call_count == 1:
+                raise freshdeskBadRequestError(
+                    "Freshdesk 300 page limit reached"
+                )
+
+        self.stream.get_records = mock_get_records
+
+        self.stream.sync(
+            self.state,
+            self.transformer,
+        )
+
+        self.assertIn(
+            "2024-01-01T05:00:00Z",
+            bookmark_values,
+        )
+
+        # Call count workflow --> call_count = 0
+        # 1. First call with normal_filters ==> call_count = 1
+        # 1. When generator resumes, it raises freshdeskBadRequestError
+        # 2. Second call with normal_filters ==> call_count = 2
+        # 3. Third call with spam_filters ==> call_count = 3
+        # 4. Fourth call with deleted_filters ==> call_count = 4
+        self.assertEqual(call_count, 4)
+
+    @patch("tap_freshdesk.streams.abstracts.LOGGER")
+    @patch("tap_freshdesk.streams.abstracts.write_record")
+    def test_max_restarts_exceeded_advances_bookmark_and_reraises(
+        self, mock_write_record, mock_logger
+    ):
+        """
+        Verify that when freshdeskBadRequestError occurs MAX_RESTARTS (10)
+        consecutive times, the bookmark is advanced by 1 second, an error is
+        logged, and the exception is re-raised.
+
+        Covers abstracts.py lines 505-528:
+          - Line 505:     if restart_count >= MAX_RESTARTS
+          - Lines 506-512: advanced_bookmark = current_max_bookmark_date + 1s
+          - Lines 514-520: LOGGER.error(...)
+          - Lines 522-526: write_bookmark called with advanced_bookmark
+          - Line 528:     raise
+        """
+        # Bookmark with microseconds to match the strptime format
+        # "%Y-%m-%dT%H:%M:%S.%fZ" used on lines 508-509
+        bookmark = "2024-01-01T00:00:00.000000Z"
+        expected_advanced_bookmark = "2024-01-01T00:00:01.000000Z"
+
+        self.stream.get_bookmark = Mock(return_value=bookmark)
+
+        bookmark_writes = []
+
+        def mock_write_bookmark(state, key, value):
+            bookmark_writes.append((key, value))
+            return state
+
+        self.stream.write_bookmark = Mock(side_effect=mock_write_bookmark)
+
+        # Always raise to exhaust all MAX_RESTARTS (10) attempts
+        def mock_get_records(state):
+            raise freshdeskBadRequestError("Freshdesk 300 page limit reached")
+
+        self.stream.get_records = mock_get_records
+
+        # Exception must be re-raised after MAX_RESTARTS attempts (line 528)
+        with self.assertRaises(freshdeskBadRequestError):
+            self.stream.sync(self.state, self.transformer)
+
+        # write_bookmark is called exactly 10 times:
+        #   - 9 times to persist progress (restart_count 1..9)
+        #   - 1 time with the advanced bookmark when restart_count = 10
+        self.assertEqual(len(bookmark_writes), 10)
+
+        # First 9 writes: persist the original bookmark unchanged
+        for key, value in bookmark_writes[:9]:
+            self.assertEqual(key, "tickets")
+            self.assertEqual(value, bookmark)
+
+        # 10th write (lines 522-526): bookmark advanced by exactly 1 second
+        last_key, last_value = bookmark_writes[-1]
+        self.assertEqual(last_key, "tickets")
+        self.assertEqual(last_value, expected_advanced_bookmark)
+
+        # LOGGER.error called once: "max restart" message (lines 514-520)
+        mock_logger.error.assert_called_once_with(
+            "Max restart attempts reached for %s. "
+            "Advancing bookmark from %s to %s and aborting sync.",
+            "tickets",
+            bookmark,
+            expected_advanced_bookmark,
+        )
+
+    @patch("tap_freshdesk.streams.abstracts.write_record")
+    def test_max_restarts_not_yet_exceeded_does_not_reraise(
+        self, mock_write_record
+    ):
+        """
+        Verify that when freshdeskBadRequestError occurs fewer than
+        MAX_RESTARTS (10) times, the sync retries without advancing
+        the bookmark or re-raising.
+
+        This tests the False branch of the `if restart_count >= MAX_RESTARTS:`
+        guard at line 505, confirming that only reaching the exact threshold
+        triggers the lines 505-528 logic.
+        """
+        bookmark = "2024-01-01T00:00:00.000000Z"
+        advanced_bookmark = "2024-01-01T00:00:01.000000Z"
+
+        self.stream.get_bookmark = Mock(return_value=bookmark)
+
+        bookmark_writes = []
+
+        def mock_write_bookmark(state, key, value):
+            bookmark_writes.append((key, value))
+            return state
+
+        self.stream.write_bookmark = Mock(side_effect=mock_write_bookmark)
+
+        call_count = 0
+        # Fail exactly MAX_RESTARTS-1 = 9 times, then succeed on the 10th call
+        MAX_RESTARTS = 10
+
+        def mock_get_records(state):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= MAX_RESTARTS - 1:
+                raise freshdeskBadRequestError(
+                    "Freshdesk 300 page limit reached"
+                )
+            yield {
+                "id": 1,
+                "updated_at": "2024-01-01T01:00:00.000000Z",
+            }
+
+        self.stream.get_records = mock_get_records
+
+        # Should complete without raising (9 failures is below MAX_RESTARTS)
+        self.stream.sync(self.state, self.transformer)
+
+        # The advanced bookmark must never have been written
+        advanced_writes = [
+            value for (_, value) in bookmark_writes
+            if value == advanced_bookmark
+        ]
+        self.assertEqual(
+            advanced_writes,
+            [],
+            "Advanced bookmark must not be written "
+            "when MAX_RESTARTS is not reached",
+        )
+
+    @patch("tap_freshdesk.streams.abstracts.LOGGER")
+    @patch("tap_freshdesk.streams.abstracts.write_record")
+    def test_max_restarts_bookmark_without_microseconds(
+        self, mock_write_record, mock_logger
+    ):
+        """
+        Bug fix: advanced_bookmark must not crash when
+        current_max_bookmark_date lacks microseconds.
+
+        Previously the code used datetime.strptime with the
+        format "%Y-%m-%dT%H:%M:%S.%fZ" which requires .ffffff.
+        A bookmark like "2024-01-01T00:00:00Z" (no microseconds)
+        would raise ValueError.  The fix uses singer's
+        strptime_to_utc which handles any ISO-8601 input.
+        """
+        # Bookmark without microseconds - previously caused ValueError
+        bookmark = "2024-01-01T00:00:00Z"
+
+        self.stream.get_bookmark = Mock(return_value=bookmark)
+
+        bookmark_writes = []
+
+        def mock_write_bookmark(state, key, value):
+            bookmark_writes.append((key, value))
+            return state
+
+        self.stream.write_bookmark = Mock(
+            side_effect=mock_write_bookmark
+        )
+
+        # Always raise to reach MAX_RESTARTS
+        def mock_get_records(state):
+            raise freshdeskBadRequestError(
+                "Freshdesk 300 page limit reached"
+            )
+
+        self.stream.get_records = mock_get_records
+
+        # Must not raise ValueError from strptime
+        with self.assertRaises(freshdeskBadRequestError):
+            self.stream.sync(self.state, self.transformer)
+
+        # The 10th write must be the advanced bookmark
+        # (1 second after "2024-01-01T00:00:00Z")
+        _, last_value = bookmark_writes[-1]
+        self.assertIn("2024-01-01T00:00:01", last_value)
+
+    @patch("tap_freshdesk.streams.abstracts.LOGGER")
+    @patch("tap_freshdesk.streams.abstracts.write_record")
+    def test_max_restarts_date_only_bookmark(
+        self, mock_write_record, mock_logger
+    ):
+        """
+        The advanced_bookmark calculation also handles a plain
+        date string start_date ("2023-01-01") without crashing.
+        singer's strptime_to_utc parses it as midnight UTC.
+        """
+        bookmark = "2023-01-01"
+
+        self.stream.get_bookmark = Mock(return_value=bookmark)
+
+        bookmark_writes = []
+
+        def mock_write_bookmark(state, key, value):
+            bookmark_writes.append((key, value))
+            return state
+
+        self.stream.write_bookmark = Mock(
+            side_effect=mock_write_bookmark
+        )
+
+        def mock_get_records(state):
+            raise freshdeskBadRequestError(
+                "Freshdesk 300 page limit reached"
+            )
+
+        self.stream.get_records = mock_get_records
+
+        with self.assertRaises(freshdeskBadRequestError):
+            self.stream.sync(self.state, self.transformer)
+
+        _, last_value = bookmark_writes[-1]
+        # 2023-01-01T00:00:00Z + 1s = 2023-01-01T00:00:01
+        self.assertIn("2023-01-01T00:00:01", last_value)

--- a/tests/unittests/test_client.py
+++ b/tests/unittests/test_client.py
@@ -1,0 +1,379 @@
+import unittest
+from unittest.mock import MagicMock, Mock, patch
+
+import requests
+
+from tap_freshdesk.client import Client, get_backoff_time, raise_for_error
+from tap_freshdesk.exceptions import (
+    freshdeskBackoffError,
+    freshdeskBadRequestError,
+    freshdeskError,
+    freshdeskInternalServerError,
+    freshdeskRateLimitError,
+    freshdeskUnauthorizedError,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_response(status_code, json_data=None, headers=None):
+    """Build a minimal mock requests.Response."""
+    resp = MagicMock(spec=requests.Response)
+    resp.status_code = status_code
+    resp.json.return_value = json_data or {}
+    resp.headers = headers or {}
+    return resp
+
+
+def _make_client():
+    return Client(
+        {
+            "api_key": "test_key",
+            "domain": "testdomain",
+            "start_date": "2023-01-01",
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# freshdeskRateLimitError
+# ---------------------------------------------------------------------------
+
+
+class TestFreshdeskRateLimitError(unittest.TestCase):
+    """Tests for the updated freshdeskRateLimitError.__init__."""
+
+    def test_retry_after_extracted_from_header(self):
+        """Retry-After header value is stored as a float."""
+        response = _make_response(429, headers={"Retry-After": "45"})
+        err = freshdeskRateLimitError("rate limited", response)
+        self.assertEqual(err.retry_after, 45.0)
+
+    def test_retry_after_float_in_header(self):
+        """Fractional Retry-After values are parsed correctly."""
+        response = _make_response(429, headers={"Retry-After": "1.5"})
+        err = freshdeskRateLimitError("rate limited", response)
+        self.assertEqual(err.retry_after, 1.5)
+
+    def test_retry_after_defaults_to_60_when_header_missing(self):
+        """Missing Retry-After header defaults to 60.0 (float) seconds."""
+        response = _make_response(429, headers={})
+        err = freshdeskRateLimitError("rate limited", response)
+        self.assertEqual(err.retry_after, 60.0)
+        self.assertIsInstance(err.retry_after, float)
+
+    def test_retry_after_defaults_to_60_on_invalid_value(self):
+        """Non-numeric Retry-After header defaults to 60 seconds."""
+        response = _make_response(
+            429, headers={"Retry-After": "not-a-number"}
+        )
+        err = freshdeskRateLimitError("rate limited", response)
+        self.assertEqual(err.retry_after, 60)
+
+    def test_retry_after_is_none_when_no_response(self):
+        """retry_after is None when no response object is given."""
+        err = freshdeskRateLimitError("rate limited")
+        self.assertIsNone(err.retry_after)
+
+    def test_message_includes_retry_after_seconds(self):
+        """Error message contains the Retry-After duration."""
+        response = _make_response(429, headers={"Retry-After": "30"})
+        err = freshdeskRateLimitError("Rate limited", response)
+        self.assertIn("Retry after 30.0 seconds", str(err))
+
+    def test_message_uses_default_text_when_no_custom_message(self):
+        """Default message is used when none is provided."""
+        response = _make_response(429, headers={"Retry-After": "30"})
+        err = freshdeskRateLimitError(response=response)
+        self.assertIn("FreshDesk Rate Limit Exceeded", str(err))
+
+    def test_message_has_no_retry_after_suffix_when_no_response(self):
+        """No 'Retry after' suffix when retry_after is None."""
+        err = freshdeskRateLimitError("Rate limited")
+        self.assertNotIn("Retry after", str(err))
+
+    def test_is_subclass_of_backoff_error(self):
+        """freshdeskRateLimitError must remain a freshdeskBackoffError."""
+        self.assertTrue(issubclass(freshdeskRateLimitError, freshdeskBackoffError))
+
+
+# ---------------------------------------------------------------------------
+# get_backoff_time
+# ---------------------------------------------------------------------------
+
+
+class TestGetBackoffTime(unittest.TestCase):
+    """Tests for the get_backoff_time() helper."""
+
+    def test_returns_retry_after_from_rate_limit_exception(self):
+        """Returns the retry_after value from a rate-limit exception."""
+        response = _make_response(429, headers={"Retry-After": "45"})
+        exception = freshdeskRateLimitError("rate limited", response)
+        result = get_backoff_time({"exception": exception})
+        self.assertEqual(result, 45.0)
+
+    def test_returns_default_when_retry_after_is_none(self):
+        """Returns 60 when the exception carries no retry_after."""
+        exception = freshdeskRateLimitError("rate limited")
+        # no response → retry_after is None
+        result = get_backoff_time({"exception": exception})
+        self.assertEqual(result, 60.0)
+
+    def test_returns_default_for_non_rate_limit_exception(self):
+        """Returns 60 when the exception is not a rate-limit error."""
+        result = get_backoff_time({"exception": Exception("generic")})
+        self.assertEqual(result, 60.0)
+
+    def test_handles_exception_passed_directly(self):
+        """Defensive branch: exception passed as the value instead of dict."""
+        exception = freshdeskRateLimitError("rate limited")
+        result = get_backoff_time(exception)
+        self.assertEqual(result, 60.0)
+
+    @patch("tap_freshdesk.client.LOGGER")
+    def test_warning_is_logged(self, mock_logger):
+        """A warning is always logged regardless of exception type."""
+        exception = freshdeskRateLimitError("rate limited")
+        get_backoff_time({"exception": exception})
+        mock_logger.warning.assert_called_once()
+
+    @patch("tap_freshdesk.client.LOGGER")
+    def test_logged_wait_time_matches_retry_after(self, mock_logger):
+        """The logged wait time matches the extracted retry_after."""
+        response = _make_response(429, headers={"Retry-After": "77"})
+        exception = freshdeskRateLimitError("rate limited", response)
+        get_backoff_time({"exception": exception})
+        logged_args = mock_logger.warning.call_args[0]
+        # second positional arg is the wait time
+        self.assertEqual(logged_args[1], 77.0)
+
+
+# ---------------------------------------------------------------------------
+# raise_for_error
+# ---------------------------------------------------------------------------
+
+
+class TestRaiseForError(unittest.TestCase):
+    """Tests for raise_for_error() HTTP status → exception mapping."""
+
+    def test_200_does_not_raise(self):
+        """A 200 response must not raise any exception."""
+        raise_for_error(_make_response(200))
+
+    def test_400_raises_bad_request_error(self):
+        with self.assertRaises(freshdeskBadRequestError):
+            raise_for_error(_make_response(400))
+
+    def test_401_raises_unauthorized_error(self):
+        with self.assertRaises(freshdeskUnauthorizedError):
+            raise_for_error(_make_response(401))
+
+    def test_429_raises_rate_limit_error(self):
+        with self.assertRaises(freshdeskRateLimitError):
+            raise_for_error(_make_response(429))
+
+    def test_500_raises_internal_server_error(self):
+        with self.assertRaises(freshdeskInternalServerError):
+            raise_for_error(_make_response(500))
+
+    def test_unknown_status_code_raises_freshdesk_error(self):
+        with self.assertRaises(freshdeskError):
+            raise_for_error(_make_response(418))
+
+    def test_error_message_taken_from_error_field(self):
+        """When JSON has an 'error' key, it appears in the exception message."""
+        response = _make_response(400, json_data={"error": "Bad input data"})
+        with self.assertRaises(freshdeskBadRequestError) as ctx:
+            raise_for_error(response)
+        self.assertIn("Bad input data", str(ctx.exception))
+
+    def test_error_message_taken_from_message_field(self):
+        """When JSON has a 'message' key, it appears in the exception message."""
+        response = _make_response(
+            400, json_data={"message": "Validation failed"}
+        )
+        with self.assertRaises(freshdeskBadRequestError) as ctx:
+            raise_for_error(response)
+        self.assertIn("Validation failed", str(ctx.exception))
+
+    def test_error_message_falls_back_to_mapping(self):
+        """When JSON has neither key, the mapping's default message is used."""
+        response = _make_response(400, json_data={})
+        with self.assertRaises(freshdeskBadRequestError) as ctx:
+            raise_for_error(response)
+        self.assertIn("400", str(ctx.exception))
+
+    def test_json_parse_failure_does_not_crash(self):
+        """If response.json() raises, raise_for_error still maps the error."""
+        response = _make_response(500)
+        response.json.side_effect = ValueError("not json")
+        with self.assertRaises(freshdeskInternalServerError):
+            raise_for_error(response)
+
+
+# ---------------------------------------------------------------------------
+# Client retry behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestClientRetryBehavior(unittest.TestCase):
+    """
+    Tests that verify the backoff/retry decorators on Client.__make_request.
+
+    Layout of decorators (outermost first):
+      @backoff.on_exception(expo,    NetworkErrors + freshdeskBackoffError)
+      @backoff.on_exception(runtime, freshdeskRateLimitError)
+      def __make_request(...)
+
+    Execution order when a request fails:
+      • freshdeskRateLimitError  → caught by inner (runtime) decorator first
+      • freshdeskBackoffError    → bypasses inner, caught by outer (expo) decorator
+      • Network errors           → bypasses inner, caught by outer (expo) decorator
+    """
+
+    def setUp(self):
+        self.client = _make_client()
+
+    # -- 429 rate-limit -------------------------------------------------------
+
+    @patch("time.sleep", return_value=None)
+    def test_rate_limit_error_is_retried(self, _mock_sleep):
+        """
+        A 429 response triggers the runtime-backoff retry.
+        Second call succeeds → result is returned.
+        """
+        self.client._session.request = Mock(
+            side_effect=[
+                _make_response(429, headers={"Retry-After": "0"}),
+                _make_response(200, json_data=[{"id": 1}]),
+            ]
+        )
+        result = self.client.get("http://test.com", {}, {})
+        self.assertEqual(self.client._session.request.call_count, 2)
+        self.assertEqual(result, [{"id": 1}])
+
+    @patch("time.sleep", return_value=None)
+    def test_rate_limit_retry_after_header_governs_sleep(self, mock_sleep):
+        """
+        The Retry-After value from the response governs the sleep duration
+        via get_backoff_time.
+        """
+        self.client._session.request = Mock(
+            side_effect=[
+                _make_response(429, headers={"Retry-After": "7"}),
+                _make_response(200, json_data=[{"id": 2}]),
+            ]
+        )
+        self.client.get("http://test.com", {}, {})
+        # time.sleep must have been called with the Retry-After value
+        sleep_calls = [call.args[0] for call in mock_sleep.call_args_list]
+        self.assertIn(7.0, sleep_calls)
+
+    # -- 5xx server errors (freshdeskBackoffError) ----------------------------
+
+    @patch("time.sleep", return_value=None)
+    def test_5xx_error_is_retried_with_expo_backoff(self, _mock_sleep):
+        """
+        Bug fix: freshdeskBackoffError (5xx) subclasses must be retried by
+        the exponential-backoff decorator.
+
+        Previously freshdeskBackoffError was removed from the outer decorator,
+        causing 5xx errors to propagate immediately without retry.
+        """
+        self.client._session.request = Mock(
+            side_effect=[
+                _make_response(500),
+                _make_response(200, json_data=[{"id": 3}]),
+            ]
+        )
+        result = self.client.get("http://test.com", {}, {})
+        self.assertEqual(self.client._session.request.call_count, 2)
+        self.assertEqual(result, [{"id": 3}])
+
+    @patch("time.sleep", return_value=None)
+    def test_502_bad_gateway_is_retried(self, _mock_sleep):
+        """502 Bad Gateway (a freshdeskBackoffError) must also be retried."""
+        self.client._session.request = Mock(
+            side_effect=[
+                _make_response(502),
+                _make_response(200, json_data=[{"id": 4}]),
+            ]
+        )
+        result = self.client.get("http://test.com", {}, {})
+        self.assertEqual(self.client._session.request.call_count, 2)
+        self.assertEqual(result, [{"id": 4}])
+
+    @patch("time.sleep", return_value=None)
+    def test_503_service_unavailable_is_retried(self, _mock_sleep):
+        """503 Service Unavailable must be retried."""
+        self.client._session.request = Mock(
+            side_effect=[
+                _make_response(503),
+                _make_response(200, json_data=[{"id": 5}]),
+            ]
+        )
+        result = self.client.get("http://test.com", {}, {})
+        self.assertEqual(self.client._session.request.call_count, 2)
+        self.assertEqual(result, [{"id": 5}])
+
+    # -- Network errors -------------------------------------------------------
+
+    @patch("time.sleep", return_value=None)
+    def test_timeout_is_retried(self, _mock_sleep):
+        """A Timeout exception must trigger exponential-backoff retry."""
+        from requests.exceptions import Timeout
+
+        self.client._session.request = Mock(
+            side_effect=[
+                Timeout(),
+                _make_response(200, json_data=[{"id": 6}]),
+            ]
+        )
+        result = self.client.get("http://test.com", {}, {})
+        self.assertEqual(self.client._session.request.call_count, 2)
+        self.assertEqual(result, [{"id": 6}])
+
+    @patch("time.sleep", return_value=None)
+    def test_connection_error_is_retried(self, _mock_sleep):
+        """A ConnectionError must trigger exponential-backoff retry."""
+        from requests.exceptions import ConnectionError as ReqConnError
+
+        self.client._session.request = Mock(
+            side_effect=[
+                ReqConnError(),
+                _make_response(200, json_data=[{"id": 7}]),
+            ]
+        )
+        result = self.client.get("http://test.com", {}, {})
+        self.assertEqual(self.client._session.request.call_count, 2)
+        self.assertEqual(result, [{"id": 7}])
+
+    # -- Non-retryable errors -------------------------------------------------
+
+    @patch("time.sleep", return_value=None)
+    def test_400_bad_request_is_not_retried(self, _mock_sleep):
+        """
+        freshdeskBadRequestError (400) does NOT extend freshdeskBackoffError
+        and must NOT be retried.
+        """
+        self.client._session.request = Mock(
+            return_value=_make_response(400)
+        )
+        with self.assertRaises(freshdeskBadRequestError):
+            self.client.get("http://test.com", {}, {})
+        # Only one attempt — no retry
+        self.assertEqual(self.client._session.request.call_count, 1)
+
+    @patch("time.sleep", return_value=None)
+    def test_rate_limit_exhausts_retries_and_reraises(self, _mock_sleep):
+        """
+        After exhausting max_tries (5) on 429s, the exception propagates.
+        """
+        self.client._session.request = Mock(
+            return_value=_make_response(429, headers={"Retry-After": "0"})
+        )
+        with self.assertRaises(freshdeskRateLimitError):
+            self.client.get("http://test.com", {}, {})
+        self.assertEqual(self.client._session.request.call_count, 5)

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -166,6 +166,23 @@ class TestAccessChecks(unittest.TestCase):
         self.assertEqual(set(schemas.keys()), {"tickets"})
         self.assertEqual(set(field_metadata.keys()), {"tickets"})
 
+    @patch("tap_freshdesk.discover.LOGGER.warning")
+    @patch("tap_freshdesk.discover.check_stream_access")
+    def test_apply_access_checks_logs_inaccessible_parent_and_child(self, mock_check, mock_warning):
+        names = ["tickets", "conversations", "agents"]
+        schemas, field_metadata = self._schemas_and_metadata(names)
+
+        def _side_effect(_client, stream_cls):
+            if stream_cls is STREAMS["tickets"]:
+                return False
+            return True
+
+        mock_check.side_effect = _side_effect
+        _apply_access_checks(MagicMock(), schemas, field_metadata)
+
+        logged_messages = [call.args[1] for call in mock_warning.call_args_list if len(call.args) > 1]
+        self.assertIn("tickets, conversations", logged_messages)
+
     @patch("tap_freshdesk.discover.STREAMS")
     def test_prune_inaccessible_children_removes_nested_descendants(self, mock_streams):
         class Parent:

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -1,0 +1,131 @@
+"""Unit tests for tap_freshdesk discover module and check_stream_access helper."""
+import unittest
+from unittest.mock import MagicMock, patch
+
+from tap_freshdesk.exceptions import freshdeskUnauthorizedError, freshdeskForbiddenError, freshdeskNoAccessibleStreamsError
+from tap_freshdesk.discover import check_stream_access, discover
+from tap_freshdesk.streams import STREAMS
+
+
+# ---------------------------------------------------------------------------
+# check_stream_access
+# ---------------------------------------------------------------------------
+
+class TestCheckStreamAccess(unittest.TestCase):
+    """Tests for the merged check_stream_access function in tap_freshdesk.discover."""
+
+    def _make_client(self, side_effect=None):
+        client = MagicMock()
+        client.base_url = "https://example.freshdesk.com/api/v2"
+        if side_effect:
+            client.get.side_effect = side_effect
+        return client
+
+    def test_child_stream_always_accessible(self):
+        """Child streams (path contains '{}') are skipped and returned as True."""
+        for stream_name, stream_cls in STREAMS.items():
+            if '{}' in stream_cls.path:
+                client = self._make_client()
+                result = check_stream_access(client, stream_cls)
+                self.assertTrue(result, msg=f"Child stream '{stream_name}' should always be True")
+                client.get.assert_not_called()
+
+    def test_top_level_stream_returns_true_when_accessible(self):
+        client = self._make_client()
+        result = check_stream_access(client, STREAMS["tickets"])
+        self.assertTrue(result)
+        client.get.assert_called_once()
+
+    def test_top_level_stream_returns_false_on_401(self):
+        client = self._make_client(side_effect=freshdeskUnauthorizedError("401"))
+        result = check_stream_access(client, STREAMS["tickets"])
+        self.assertFalse(result)
+
+    def test_top_level_stream_returns_false_on_403(self):
+        client = self._make_client(side_effect=freshdeskForbiddenError("403"))
+        result = check_stream_access(client, STREAMS["agents"])
+        self.assertFalse(result)
+
+    def test_top_level_stream_reraises_other_errors(self):
+        client = self._make_client(side_effect=ConnectionError("timeout"))
+        with self.assertRaises(ConnectionError):
+            check_stream_access(client, STREAMS["contacts"])
+
+    def test_probe_url_is_built_from_base_url_and_path(self):
+        """Verifies the endpoint passed to client.get is base_url + path."""
+        client = self._make_client()
+        stream_cls = STREAMS["tickets"]
+        check_stream_access(client, stream_cls)
+        call_kwargs = client.get.call_args
+        called_endpoint = call_kwargs.kwargs.get("endpoint") or call_kwargs[1].get("endpoint")
+        self.assertIn(stream_cls.path, called_endpoint)
+
+
+# ---------------------------------------------------------------------------
+# discover()
+# ---------------------------------------------------------------------------
+
+class TestDiscover(unittest.TestCase):
+    """Tests for the discover() function in tap_freshdesk.discover."""
+
+    def _minimal_schema_pair(self, stream_names):
+        schemas = {n: {"type": "object", "properties": {}} for n in stream_names}
+        meta = {n: [{"metadata": {"table-key-properties": ["id"]}, "breadcrumb": []}]
+                for n in stream_names}
+        return schemas, meta
+
+    @patch("tap_freshdesk.discover.get_schemas")
+    @patch("tap_freshdesk.discover.check_stream_access")
+    def test_all_accessible_streams_in_catalog(self, mock_check, mock_get_schemas):
+        """All streams accessible → all appear in the catalog."""
+        stream_names = list(STREAMS.keys())
+        mock_get_schemas.return_value = self._minimal_schema_pair(stream_names)
+        mock_check.return_value = True
+
+        client = MagicMock()
+        catalog = discover(client)
+        returned = {s.tap_stream_id for s in catalog.streams}
+        self.assertEqual(returned, set(stream_names))
+
+    @patch("tap_freshdesk.discover.get_schemas")
+    @patch("tap_freshdesk.discover.check_stream_access")
+    def test_inaccessible_stream_excluded(self, mock_check, mock_get_schemas):
+        """A stream returning False from access check is excluded from the catalog."""
+        stream_names = list(STREAMS.keys())
+        blocked = "agents"
+        mock_get_schemas.return_value = self._minimal_schema_pair(stream_names)
+        mock_check.side_effect = lambda client, cls: cls is not STREAMS[blocked]
+
+        client = MagicMock()
+        catalog = discover(client)
+        returned = {s.tap_stream_id for s in catalog.streams}
+        self.assertNotIn(blocked, returned)
+        self.assertEqual(returned, set(stream_names) - {blocked})
+
+    @patch("tap_freshdesk.discover.get_schemas")
+    @patch("tap_freshdesk.discover.check_stream_access")
+    def test_all_inaccessible_raises_exception(self, mock_check, mock_get_schemas):
+        """When all streams are inaccessible, discover() raises freshdeskNoAccessibleStreamsError."""
+        mock_get_schemas.return_value = self._minimal_schema_pair(list(STREAMS.keys()))
+        mock_check.return_value = False
+
+        client = MagicMock()
+        with self.assertRaises(freshdeskNoAccessibleStreamsError) as ctx:
+            discover(client)
+        self.assertIn("The credentials do not have read access to any of the supported streams", str(ctx.exception))
+
+    @patch("tap_freshdesk.discover.get_schemas")
+    @patch("tap_freshdesk.discover.check_stream_access")
+    def test_check_called_for_every_stream(self, mock_check, mock_get_schemas):
+        """check_stream_access is called exactly once per stream."""
+        stream_names = list(STREAMS.keys())
+        mock_get_schemas.return_value = self._minimal_schema_pair(stream_names)
+        mock_check.return_value = True
+
+        client = MagicMock()
+        discover(client)
+        self.assertEqual(mock_check.call_count, len(stream_names))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -1,130 +1,197 @@
-"""Unit tests for tap_freshdesk discover module and check_stream_access helper."""
+"""Unit tests for discovery access checks and catalog pruning."""
 import unittest
 from unittest.mock import MagicMock, patch
 
-from tap_freshdesk.exceptions import freshdeskUnauthorizedError, freshdeskForbiddenError, freshdeskNoAccessibleStreamsError
-from tap_freshdesk.discover import check_stream_access, discover
+from tap_freshdesk.discover import (
+    _apply_access_checks,
+    _prune_inaccessible_children,
+    check_stream_access,
+    discover,
+)
+from tap_freshdesk.exceptions import freshdeskNotFoundError
+from tap_freshdesk.exceptions import freshdeskNoAccessibleStreamsError
 from tap_freshdesk.streams import STREAMS
 
 
-# ---------------------------------------------------------------------------
-# check_stream_access
-# ---------------------------------------------------------------------------
-
 class TestCheckStreamAccess(unittest.TestCase):
-    """Tests for the merged check_stream_access function in tap_freshdesk.discover."""
+    """Tests for stream-level access probing wrapper."""
 
-    def _make_client(self, side_effect=None):
+    def test_wrapper_uses_stream_check_access(self):
+        client = MagicMock()
+
+        class FakeStream:
+            def __init__(self, client=None, catalog=None):
+                self.client = client
+
+            def check_access(self):
+                return True
+
+        self.assertTrue(check_stream_access(client, FakeStream))
+
+    def test_child_stream_is_probed(self):
         client = MagicMock()
         client.base_url = "https://example.freshdesk.com/api/v2"
-        if side_effect:
-            client.get.side_effect = side_effect
-        return client
+        client.get.side_effect = [
+            [{"id": 101}],
+            [{"id": 1, "updated_at": "2024-01-01T00:00:00Z"}],
+        ]
 
-    def test_child_stream_always_accessible(self):
-        """Child streams (path contains '{}') are skipped and returned as True."""
-        for stream_name, stream_cls in STREAMS.items():
-            if '{}' in stream_cls.path:
-                client = self._make_client()
-                result = check_stream_access(client, stream_cls)
-                self.assertTrue(result, msg=f"Child stream '{stream_name}' should always be True")
-                client.get.assert_not_called()
+        result = check_stream_access(client, STREAMS["conversations"])
 
-    def test_top_level_stream_returns_true_when_accessible(self):
-        client = self._make_client()
-        result = check_stream_access(client, STREAMS["tickets"])
         self.assertTrue(result)
+        self.assertEqual(client.get.call_count, 2)
+        first_endpoint = client.get.call_args_list[0].kwargs["endpoint"]
+        second_endpoint = client.get.call_args_list[1].kwargs["endpoint"]
+        self.assertEqual(first_endpoint, f"{client.base_url}/tickets")
+        self.assertEqual(second_endpoint, f"{client.base_url}/tickets/101/conversations")
+
+    def test_child_stream_probe_raises_for_generic_404(self):
+        client = MagicMock()
+        client.base_url = "https://example.freshdesk.com/api/v2"
+        client.get.side_effect = [
+            [{"id": 101}],
+            freshdeskNotFoundError("404"),
+        ]
+
+        with self.assertRaises(freshdeskNotFoundError):
+            check_stream_access(client, STREAMS["conversations"])
+        self.assertEqual(client.get.call_count, 2)
+
+    def test_child_stream_probe_returns_false_for_account_not_found_404(self):
+        client = MagicMock()
+        client.base_url = "https://example.freshdesk.com/api/v2"
+        client.get.side_effect = [
+            [{"id": 101}],
+            freshdeskNotFoundError("HTTP-error-code: 404, Error: Account not found for the provided domain"),
+        ]
+
+        result = check_stream_access(client, STREAMS["conversations"])
+
+        self.assertFalse(result)
+        self.assertEqual(client.get.call_count, 2)
+
+    def test_parent_stream_probe_returns_false_for_account_not_found_404(self):
+        client = MagicMock()
+        client.base_url = "https://example.freshdesk.com/api/v2"
+        client.get.side_effect = freshdeskNotFoundError(
+            "HTTP-error-code: 404, Error: Account not found for the provided domain"
+        )
+
+        result = check_stream_access(client, STREAMS["tickets"])
+
+        self.assertFalse(result)
         client.get.assert_called_once()
 
-    def test_top_level_stream_returns_false_on_401(self):
-        client = self._make_client(side_effect=freshdeskUnauthorizedError("401"))
-        result = check_stream_access(client, STREAMS["tickets"])
-        self.assertFalse(result)
 
-    def test_top_level_stream_returns_false_on_403(self):
-        client = self._make_client(side_effect=freshdeskForbiddenError("403"))
-        result = check_stream_access(client, STREAMS["agents"])
-        self.assertFalse(result)
+class TestAccessChecks(unittest.TestCase):
+    """Tests for in-place stream access filtering."""
 
-    def test_top_level_stream_reraises_other_errors(self):
-        client = self._make_client(side_effect=ConnectionError("timeout"))
-        with self.assertRaises(ConnectionError):
-            check_stream_access(client, STREAMS["contacts"])
+    def _schemas_and_metadata(self, names):
+        schemas = {name: {"type": "object", "properties": {}} for name in names}
+        field_metadata = {
+            name: [{"metadata": {"table-key-properties": ["id"]}, "breadcrumb": []}]
+            for name in names
+        }
+        return schemas, field_metadata
 
-    def test_probe_url_is_built_from_base_url_and_path(self):
-        """Verifies the endpoint passed to client.get is base_url + path."""
-        client = self._make_client()
-        stream_cls = STREAMS["tickets"]
-        check_stream_access(client, stream_cls)
-        call_kwargs = client.get.call_args
-        called_endpoint = call_kwargs.kwargs.get("endpoint") or call_kwargs[1].get("endpoint")
-        self.assertIn(stream_cls.path, called_endpoint)
+    @patch("tap_freshdesk.discover.check_stream_access", return_value=True)
+    def test_apply_access_checks_keeps_all_accessible_streams(self, _mock_check):
+        names = ["tickets", "conversations", "agents"]
+        schemas, field_metadata = self._schemas_and_metadata(names)
 
+        _apply_access_checks(MagicMock(), schemas, field_metadata)
 
-# ---------------------------------------------------------------------------
-# discover()
-# ---------------------------------------------------------------------------
+        self.assertEqual(set(schemas.keys()), set(names))
+        self.assertEqual(set(field_metadata.keys()), set(names))
+
+    @patch("tap_freshdesk.discover.check_stream_access")
+    def test_apply_access_checks_removes_inaccessible_streams(self, mock_check):
+        names = ["tickets", "agents"]
+        schemas, field_metadata = self._schemas_and_metadata(names)
+
+        def _side_effect(_client, stream_cls):
+            return stream_cls is not STREAMS["agents"]
+
+        mock_check.side_effect = _side_effect
+        _apply_access_checks(MagicMock(), schemas, field_metadata)
+
+        self.assertEqual(set(schemas.keys()), {"tickets"})
+        self.assertEqual(set(field_metadata.keys()), {"tickets"})
+
+    @patch("tap_freshdesk.discover.STREAMS")
+    def test_prune_inaccessible_children_removes_nested_descendants(self, mock_streams):
+        class Parent:
+            parent = ""
+
+        class Child:
+            parent = "parent"
+
+        class GrandChild:
+            parent = "child"
+
+        mock_streams.items.return_value = [
+            ("parent", Parent),
+            ("child", Child),
+            ("grandchild", GrandChild),
+        ]
+
+        schemas = {"child": {}, "grandchild": {}}
+        field_metadata = {"child": [], "grandchild": []}
+
+        _prune_inaccessible_children(schemas, field_metadata)
+
+        self.assertEqual(schemas, {})
+        self.assertEqual(field_metadata, {})
+
+    @patch("tap_freshdesk.discover.check_stream_access", return_value=False)
+    def test_apply_access_checks_raises_when_no_stream_access(self, _mock_check):
+        names = ["tickets", "conversations"]
+        schemas, field_metadata = self._schemas_and_metadata(names)
+
+        with self.assertRaises(freshdeskNoAccessibleStreamsError):
+            _apply_access_checks(MagicMock(), schemas, field_metadata)
+
 
 class TestDiscover(unittest.TestCase):
-    """Tests for the discover() function in tap_freshdesk.discover."""
+    """Tests for discover() with access-check orchestration."""
 
     def _minimal_schema_pair(self, stream_names):
-        schemas = {n: {"type": "object", "properties": {}} for n in stream_names}
-        meta = {n: [{"metadata": {"table-key-properties": ["id"]}, "breadcrumb": []}]
-                for n in stream_names}
-        return schemas, meta
+        schemas = {name: {"type": "object", "properties": {}} for name in stream_names}
+        metadata_map = {
+            name: [{"metadata": {"table-key-properties": ["id"]}, "breadcrumb": []}]
+            for name in stream_names
+        }
+        return schemas, metadata_map
 
+    @patch("tap_freshdesk.discover._apply_access_checks")
     @patch("tap_freshdesk.discover.get_schemas")
-    @patch("tap_freshdesk.discover.check_stream_access")
-    def test_all_accessible_streams_in_catalog(self, mock_check, mock_get_schemas):
-        """All streams accessible → all appear in the catalog."""
-        stream_names = list(STREAMS.keys())
+    def test_discover_calls_access_checks_before_catalog_build(self, mock_get_schemas, mock_apply):
+        stream_names = ["tickets", "conversations"]
         mock_get_schemas.return_value = self._minimal_schema_pair(stream_names)
-        mock_check.return_value = True
 
         client = MagicMock()
         catalog = discover(client)
-        returned = {s.tap_stream_id for s in catalog.streams}
-        self.assertEqual(returned, set(stream_names))
+
+        self.assertEqual({entry.tap_stream_id for entry in catalog.streams}, set(stream_names))
+        mock_apply.assert_called_once()
 
     @patch("tap_freshdesk.discover.get_schemas")
     @patch("tap_freshdesk.discover.check_stream_access")
-    def test_inaccessible_stream_excluded(self, mock_check, mock_get_schemas):
-        """A stream returning False from access check is excluded from the catalog."""
-        stream_names = list(STREAMS.keys())
-        blocked = "agents"
+    def test_discover_excludes_child_when_parent_is_inaccessible(self, mock_check, mock_get_schemas):
+        stream_names = ["tickets", "conversations", "agents"]
         mock_get_schemas.return_value = self._minimal_schema_pair(stream_names)
-        mock_check.side_effect = lambda client, cls: cls is not STREAMS[blocked]
 
-        client = MagicMock()
-        catalog = discover(client)
-        returned = {s.tap_stream_id for s in catalog.streams}
-        self.assertNotIn(blocked, returned)
-        self.assertEqual(returned, set(stream_names) - {blocked})
+        def _side_effect(_client, stream_cls):
+            if stream_cls is STREAMS["tickets"]:
+                return False
+            return True
 
-    @patch("tap_freshdesk.discover.get_schemas")
-    @patch("tap_freshdesk.discover.check_stream_access")
-    def test_all_inaccessible_raises_exception(self, mock_check, mock_get_schemas):
-        """When all streams are inaccessible, discover() raises freshdeskNoAccessibleStreamsError."""
-        mock_get_schemas.return_value = self._minimal_schema_pair(list(STREAMS.keys()))
-        mock_check.return_value = False
+        mock_check.side_effect = _side_effect
 
-        client = MagicMock()
-        with self.assertRaises(freshdeskNoAccessibleStreamsError) as ctx:
-            discover(client)
-        self.assertIn("The credentials do not have read access to any of the supported streams", str(ctx.exception))
+        catalog = discover(MagicMock())
+        stream_ids = {entry.tap_stream_id for entry in catalog.streams}
 
-    @patch("tap_freshdesk.discover.get_schemas")
-    @patch("tap_freshdesk.discover.check_stream_access")
-    def test_check_called_for_every_stream(self, mock_check, mock_get_schemas):
-        """check_stream_access is called exactly once per stream."""
-        stream_names = list(STREAMS.keys())
-        mock_get_schemas.return_value = self._minimal_schema_pair(stream_names)
-        mock_check.return_value = True
-
-        client = MagicMock()
-        discover(client)
-        self.assertEqual(mock_check.call_count, len(stream_names))
+        self.assertEqual(stream_ids, {"agents"})
 
 
 if __name__ == "__main__":

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -10,6 +10,7 @@ from tap_freshdesk.discover import (
 )
 from tap_freshdesk.exceptions import freshdeskNotFoundError
 from tap_freshdesk.exceptions import freshdeskNoAccessibleStreamsError
+from tap_freshdesk.exceptions import freshdeskForbiddenError
 from tap_freshdesk.exceptions import freshdeskUnauthorizedError
 from tap_freshdesk.streams import STREAMS
 
@@ -82,6 +83,52 @@ class TestCheckStreamAccess(unittest.TestCase):
 
         self.assertFalse(result)
         client.get.assert_called_once()
+
+    def test_parent_stream_probe_returns_false_for_401(self):
+        client = MagicMock()
+        client.base_url = "https://example.freshdesk.com/api/v2"
+        client.get.side_effect = freshdeskUnauthorizedError("401")
+
+        result = check_stream_access(client, STREAMS["tickets"])
+
+        self.assertFalse(result)
+        client.get.assert_called_once()
+
+    def test_parent_stream_probe_returns_false_for_403(self):
+        client = MagicMock()
+        client.base_url = "https://example.freshdesk.com/api/v2"
+        client.get.side_effect = freshdeskForbiddenError("403")
+
+        result = check_stream_access(client, STREAMS["tickets"])
+
+        self.assertFalse(result)
+        client.get.assert_called_once()
+
+    def test_child_stream_probe_returns_false_for_401(self):
+        client = MagicMock()
+        client.base_url = "https://example.freshdesk.com/api/v2"
+        client.get.side_effect = [
+            [{"id": 101}],
+            freshdeskUnauthorizedError("401"),
+        ]
+
+        result = check_stream_access(client, STREAMS["conversations"])
+
+        self.assertFalse(result)
+        self.assertEqual(client.get.call_count, 2)
+
+    def test_child_stream_probe_returns_false_for_403(self):
+        client = MagicMock()
+        client.base_url = "https://example.freshdesk.com/api/v2"
+        client.get.side_effect = [
+            [{"id": 101}],
+            freshdeskForbiddenError("403"),
+        ]
+
+        result = check_stream_access(client, STREAMS["conversations"])
+
+        self.assertFalse(result)
+        self.assertEqual(client.get.call_count, 2)
 
 
 class TestAccessChecks(unittest.TestCase):

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -10,6 +10,7 @@ from tap_freshdesk.discover import (
 )
 from tap_freshdesk.exceptions import freshdeskNotFoundError
 from tap_freshdesk.exceptions import freshdeskNoAccessibleStreamsError
+from tap_freshdesk.exceptions import freshdeskUnauthorizedError
 from tap_freshdesk.streams import STREAMS
 
 
@@ -173,7 +174,20 @@ class TestDiscover(unittest.TestCase):
         catalog = discover(client)
 
         self.assertEqual({entry.tap_stream_id for entry in catalog.streams}, set(stream_names))
+        client.check_api_credentials.assert_called_once()
         mock_apply.assert_called_once()
+
+    @patch("tap_freshdesk.discover._apply_access_checks")
+    @patch("tap_freshdesk.discover.get_schemas")
+    def test_discover_fails_fast_for_invalid_credentials(self, mock_get_schemas, mock_apply):
+        client = MagicMock()
+        client.check_api_credentials.side_effect = freshdeskUnauthorizedError("invalid credentials")
+
+        with self.assertRaises(freshdeskUnauthorizedError):
+            discover(client)
+
+        mock_get_schemas.assert_not_called()
+        mock_apply.assert_not_called()
 
     @patch("tap_freshdesk.discover.get_schemas")
     @patch("tap_freshdesk.discover.check_stream_access")


### PR DESCRIPTION
# Description of change
https://github.com/singer-io/tap-freshdesk/pull/64
https://github.com/singer-io/tap-freshdesk/pull/66
https://github.com/singer-io/tap-freshdesk/pull/69

* Add access validation during discovery
* Refine exception messaging
* Update unit tests for access-check behavior
* Bump version and changelog
* Added metadata changes
* Handled freshdesk's ticket stream limitation of max 300 pages.
* Tap now catches the 400 error and retries the sync with last record's bookmark state
* Also modified ratelimit handling to honor the Retry-After header.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
